### PR TITLE
Change SSP preview TAG from gcloud to dos

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -6,7 +6,7 @@
   },
   {"name": "ssp-preview", "display_name": "SSP preview",
    "description": "Run the SSP functional test suite against the preview environment",
-   "tags": ["@ssp-gcloud"],
+   "tags": ["@ssp-dos"],
    "disabled": "true",
   }
 ] %}


### PR DESCRIPTION
This is so that the SSP tests can be run for DOS2
