### PR TITLE
Use github.com instead of Enterprise

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -35,7 +35,7 @@
                   sh("git reset --hard origin/master")
                 }
                 dir('agreements') {
-                  git url: "git@github.digital.cabinet-office.gov.uk:gds/digitalmarketplace-agreements.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+                  git url: "git@github.com:alphagov/digitalmarketplace-agreements.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
                   echo "Cleaning agreements repository"
                   sh('pwd')
                   sh("git clean -fdx")

--- a/job_definitions/performance_testing.yml
+++ b/job_definitions/performance_testing.yml
@@ -73,7 +73,7 @@
       artifactDaysToKeep: 4
     scm:
       - git:
-          url: git@github.digital.cabinet-office.gov.uk:gds/digitalmarketplace-performance-testing.git
+          url: git@github.com:alphagov/digitalmarketplace-performance-testing.git
           credentials-id: github_com_and_enterprise
           branches:
             - master

--- a/playbooks/roles/jenkins/tasks/jobs.yml
+++ b/playbooks/roles/jenkins/tasks/jobs.yml
@@ -24,7 +24,7 @@
 - name: Clone digitalmarketplace-credentials repository
   tags: [credentials-repo]
   git:
-    repo: "git@github.digital.cabinet-office.gov.uk:gds/digitalmarketplace-credentials.git"
+    repo: "git@github.com:alphagov/digitalmarketplace-credentials.git"
     dest: /var/lib/jenkins/digitalmarketplace-credentials
   sudo: yes
   sudo_user: jenkins


### PR DESCRIPTION
Repo's on github.digital.cabinet-office.gov.uk have been moved to
github.com. Jobs which use the old repos have been pointed at the new
reops.

This doesn't include the manual because whilst we can keep the manuals
repo private on github.com, if the job to build the pages is run we risk
leaking sensitive information. There is a story to check the manual for
this info.