### PR TITLE
Point manual job at github.com instead of Enterprise

### DIFF
--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -6,7 +6,7 @@
     description: "Automatically publish digitalmarketplace manual to gh pages."
     scm:
       - git:
-          url: git@github.digital.cabinet-office.gov.uk:gds/digitalmarketplace-manual.git
+          url: git@github.com:alphagov/digitalmarketplace-manual.git
           credentials-id: github_com_and_enterprise
           branches:
             - master


### PR DESCRIPTION
The manual has been moved to a private repo in Github. The job needs the
new url.