### PR TITLE
Update ansible host to ci.marketplace.team

### DIFF
--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,2 +1,2 @@
 [jenkins]
-ci.beta.digitalmarketplace.service.gov.uk
+ci.marketplace.team


### PR DESCRIPTION
Jenkins was moved to ci.markeplace.team a while ago, however the
beta.digitalmarketplace.service.gov.uk domain was still routing to the
box. It's been removed, so this host needs updating.