### PR TITLE
Add briefs frontend to Jenkins setup

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -17,6 +17,7 @@ jobs: '*'
 dm_applications:
   - api
   - search-api
+  - briefs-frontend
   - buyer-frontend
   - supplier-frontend
   - admin-frontend
@@ -86,6 +87,7 @@ jenkins_list_views:
     jobs:
       - release-api
       - release-admin-frontend
+      - release-briefs-frontend
       - release-buyer-frontend
       - release-search-api
       - release-supplier-frontend


### PR DESCRIPTION
The briefs frontend will be split out of the buyer frontend. We add it
to the list of apps here so that jenkins will create the release
pipelines for it, ahead of the app being created.