### PR TITLE
Install liberation fonts so we have arial for agreements

### DIFF
--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -30,6 +30,7 @@
     - jq
     - xvfb
     - wkhtmltopdf
+    - fonts-liberation
 
 - name: Install rbenv and pyenv
   sudo: yes


### PR DESCRIPTION
There's still a size issue, but this at least has fonts that look the same as the framework agreements we've sent out unsigned.