### PR TITLE
Tag release Docker container with `latest`

### DIFF
--- a/job_definitions/build_application.yml
+++ b/job_definitions/build_application.yml
@@ -52,6 +52,7 @@
                     }
 
                     sh("docker push digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}")
+                    sh("docker push digitalmarketplace/${APPLICATION_NAME}:latest")
                 }
             } catch(err) {
                 currentBuild.result = 'FAILURE'


### PR DESCRIPTION
Adding a `latest` tag each time we build a new release container
allows us to pull the set of current images for each app without
checking the current release versions.