### PR TITLE
Run daily job to send emails to suppliers about new questions and answers

### DIFF
--- a/job_definitions/notify_buyers_when_requirements_close.yml
+++ b/job_definitions/notify_buyers_when_requirements_close.yml
@@ -1,4 +1,4 @@
-{% set environments = ['preview', 'production'] %}
+{% set environments = ['production'] %}
 ---
 {% for environment in environments %}
 - job:

--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -32,7 +32,7 @@
             - master
           wipe-workspace: false
     triggers:
-      - timed: "0 8 * * 1-5"
+      - timed: "H 8 * * 1-5"
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -23,7 +23,7 @@
           wipe-workspace: false
 {% if environment == 'production' %}
     triggers:
-      - timed: "0 8 * * *"
+      - timed: "H 8 * * *"
 {% endif %}
     publishers:
       - trigger-parameterized-builds:

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -44,7 +44,7 @@
           . ./venv/bin/activate
           pip install -r requirements.txt
 
-          if [ -n "SUPPLIER_IDS" ]; then
+          if [ -n "$SUPPLIER_IDS" ]; then
             FLAGS="--supplier-ids=$SUPPLIER_IDS"
           fi
 

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -21,8 +21,10 @@
           branches:
             - master
           wipe-workspace: false
+{% if environment == 'production' %}
     triggers:
       - timed: "0 8 * * *"
+{% endif %}
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -1,4 +1,4 @@
-{% set environments = ['preview', 'production'] %}
+{% set environments = ['production'] %}
 ---
 {% for environment in environments %}
 - job:
@@ -21,10 +21,8 @@
           branches:
             - master
           wipe-workspace: false
-{% if environment == 'production' %}
     triggers:
       - timed: "H 8 * * *"
-{% endif %}
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -8,8 +8,8 @@
     description: "Send email notifications to supplier users about new questions and answers."
     parameters:
       - string:
-          name: EXCLUDE_SUPPLIER_IDS
-          description: "List of supplier IDs to be excluded from the email notification"
+          name: SUPPLIER_IDS
+          description: "List of supplier IDs to be emailed e.g. 3,4,6"
       - bool:
           name: DRY_RUN
           default: false
@@ -28,9 +28,9 @@
           - project: notify-slack
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
-              USERNAME=notify-suppliers
-              JOB=Notify suppliers of new questions answers {{ environment }}
-              ICON=:alarm_clock:
+              USERNAME=question-and-answers
+              JOB=Notify suppliers of new questions and answers {{ environment }}
+              ICON=:question:
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
@@ -42,8 +42,8 @@
           . ./venv/bin/activate
           pip install -r requirements.txt
 
-          if [ -n "EXCLUDE_SUPPLIER_IDS" ]; then
-            FLAGS="--exclude-supplier-ids=$EXCLUDE_SUPPLIER_IDS"
+          if [ -n "SUPPLIER_IDS" ]; then
+            FLAGS="--supplier-ids=$SUPPLIER_IDS"
           fi
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -1,0 +1,54 @@
+{% set environments = ['preview', 'production'] %}
+---
+{% for environment in environments %}
+- job:
+    name: "notify-suppliers-of-new-questions-answers-{{ environment }}"
+    display-name: "Notify suppliers of new questions and answers - {{ environment }}"
+    project-type: freestyle
+    description: "Send email notifications to supplier users about new questions and answers."
+    parameters:
+      - string:
+          name: EXCLUDE_SUPPLIER_IDS
+          description: "List of supplier IDs to be excluded from the email notification"
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "List notifications that would be sent without sending the emails"
+    scm:
+      - git:
+          url: git@github.com:alphagov/digitalmarketplace-scripts.git
+          credentials-id: github_com_and_enterprise
+          branches:
+            - master
+          wipe-workspace: false
+    triggers:
+      - timed: "0 8 * * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=notify-suppliers
+              JOB=Notify suppliers of new questions answers {{ environment }}
+              ICON=:alarm_clock:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          [ -d venv ] || virtualenv venv
+
+          . ./venv/bin/activate
+          pip install -r requirements.txt
+
+          if [ -n "EXCLUDE_SUPPLIER_IDS" ]; then
+            FLAGS="--exclude-supplier-ids=$EXCLUDE_SUPPLIER_IDS"
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+
+          ./scripts/notify-suppliers-of-new-questions-answers.py '{{ environment }}' --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --mandrill-api-key="$MANDRILL_API_KEY_{{ environment|upper }}" $FLAGS
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -60,6 +60,7 @@ build_monitor_jobs:
   - index-services-production
   - notify-buyers-when-requirements-close-production
   - notify-suppliers-of-dos-opportunities-production
+  - notify-suppliers-of-new-questions-answers-production
   - upload-dos-opportunities-email-list-production
 
 jenkins_list_views:


### PR DESCRIPTION
This script will run everyday at 8am - https://github.com/alphagov/digitalmarketplace-scripts/pull/132

Trello: https://trello.com/c/2noI0EFB/472-3-tell-interested-suppliers-that-a-question-has-been-answered

