### PR TITLE
Add a job to publish framework applications guidance

### DIFF
--- a/job_definitions/publish_framework_application_guidance.yml
+++ b/job_definitions/publish_framework_application_guidance.yml
@@ -1,0 +1,26 @@
+- job:
+    name: publish-framework-application-guidance
+    display-name: Publish framework application guidance
+    project-type: pipeline
+    description: |
+      Builds digitalmarketplace-framework-application-guidance and publishes it on Github Pages
+    disabled: false
+    concurrent: false
+    triggers:
+      - pollscm: "* * * * *"
+    pipeline:
+      script: |
+        node {
+          stage('Prepare') {
+            git url: "git@github.com:alphagov/digitalmarketplace-framework-application-guidance.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+            sh("rbenv install -s")
+            sh("gem install bundler --conservative")
+            sh("make requirements")
+          }
+
+          stage('Build and publish') {
+            sh("git config user.name 'Jenkins'")
+            sh("git config user.email '{{ jenkins_github_email }}'")
+            sh("make publish")
+          }
+        }


### PR DESCRIPTION
Runs on new commits in digitalmarketplace-framework-application-guidance
and publishes the rendered html on Github Pages. This is similar
to the manual and frontend-toolkit publishing, but is implemented
with a pipeline job and repo Makefile is using `git worktree` to
commit only the build artefacts to gh-pages branch.