### PR TITLE
Create job for taking regular database backups

### DIFF
--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -33,9 +33,9 @@
         currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
           withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=${STAGE}"]) {
             try {
-              git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'
 
               stage('Prepare') {
+                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'
                 build job: "update-credentials"
               }
 
@@ -67,9 +67,14 @@
                     }
                     return (taskStatus == 'SUCCEEDED');
                   }
-                  notify_slack(':file_cabinet:', 'SUCCESS')
                 }
               }
+
+              stage('Check decryption') {
+                sh('./scripts/check-db-dump-is-decryptable.sh')
+                notify_slack(':file_cabinet:', 'SUCCESS')
+              }
+
             } catch(err) {
                 notify_slack(':-1:', 'FAILURE')
                 echo "Error caught"

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -30,7 +30,7 @@
                   pip install -r requirements.txt
                   make preview deploy-db-backup-app
                 ''')
-                timeout(2) {
+                timeout(10) {
                   waitUntil {
                     sleep 5
                     def taskStatus = sh(

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -1,0 +1,84 @@
+- job:
+    name: database-backup
+    display-name: Create offsite backup of database
+    project-type: pipeline
+    description: Takes a snapshot of the database, compresses it, encrypts it and uploads to S3.
+    disabled: false
+    concurrent: true
+    pipeline:
+      script: |
+        node {
+            try {
+              dir('aws') {
+                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+
+                stage('Prepare') {
+                  build job: "update-credentials"
+                }
+
+                stage('Create compressed, encrypted DB dump') {
+                  withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=preview"]) {
+                    paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+                    withEnv(paas_credentials.tokenize("\n")) {
+                      sh('make paas-login')
+                    }
+
+                  echo "Logged in to PaaS"
+
+                  sh('''
+                    cf create-service-key digitalmarketplace_api_db DATA_MIGRATION_KEY
+                    KEY_DATA=$(cf curl /v2/service_keys/$(cf service-key digitalmarketplace_api_db DATA_MIGRATION_KEY --guid))
+                    DB_HOST=$(echo $KEY_DATA | jq -r \'.entity.credentials.host\')
+                    DB_PASSWORD=$(echo $KEY_DATA | jq -r \'.entity.credentials.password\')
+                    DB_USERNAME=$(echo $KEY_DATA | jq -r \'.entity.credentials.username\')
+                    DB_NAME=$(echo $KEY_DATA | jq -r \'.entity.credentials.name\')
+                    cf ssh api -N -L 63306:$DB_HOST:5432 &
+                    SSH_PID=$!
+                    sleep 10
+                    OUTFILE_NAME=$(date +"%Y%m%d%H%M")
+                    pg_dump postgres://$DB_USERNAME:$DB_PASSWORD@localhost:63306/$DB_NAME --no-acl --no-owner | gzip | \
+                      openssl smime -encrypt -aes256 -binary -outform DEM -out ${OUTFILE_NAME}.gzip.ssl ${DM_CREDENTIALS_REPO}/jenkins-vars/db-dump-encryption-keypair/backup_key.pem.pub
+                    kill "$SSH_PID"
+                    cf delete-service-key -f digitalmarketplace_api_db DATA_MIGRATION_KEY
+                  ''')
+
+                  echo "Post dump generation"
+
+                  }
+                }
+              }
+
+              stage('Upload to S3') {
+                echo "Starting upload"
+                dir('scripts') {
+                  git url: "git@github.com:alphagov/digitalmarketplace-scripts.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+                  sh('''
+                    [ -d venv ] || virtualenv venv
+                    source ./venv/bin/activate
+                    pip install --upgrade pip
+                    pip install -r requirements.txt
+                    python ./scripts/upload-db-dump-to-s3.py preview "../aws/${OUTFILE_NAME}"
+                  ''')
+                }
+              }
+
+              stage('Cleanup') {
+                dir('aws') {
+                  rm ${OUTFILE_NAME}.gzip.ssl
+                }
+              }
+
+
+            } catch(err) {
+                echo "Error caught"
+                dir('aws') {
+                  rm ${OUTFILE_NAME}.gzip.ssl
+                }
+                echo "Gonna clean the PaaS"
+                sh('make paas-clean')
+                currentBuild.result = 'FAILURE'
+                echo "Error: ${err}"
+            } finally {
+                sh('make paas-clean')
+            }
+        }

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -8,77 +8,53 @@
     pipeline:
       script: |
         node {
+          withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=preview"]) {
             try {
-              dir('aws') {
-                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+              git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'
 
-                stage('Prepare') {
-                  build job: "update-credentials"
+              stage('Prepare') {
+                build job: "update-credentials"
+              }
+
+              stage('Login to Cloud Foundry') {
+                paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+                withEnv(paas_credentials.tokenize("\n")) {
+                  sh('make paas-login')
                 }
+              }
 
-                stage('Create compressed, encrypted DB dump') {
-                  withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=preview"]) {
-                    paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
-                    withEnv(paas_credentials.tokenize("\n")) {
-                      sh('make paas-login')
+              stage('Connect to service, create dump and upload to S3') {
+                sh('''
+                  [ -d venv ] || virtualenv venv
+                  . ./venv/bin/activate
+                  pip install -r requirements.txt
+                  make preview deploy-db-snapshot
+                ''')
+                timeout(2) {
+                  waitUntil {
+                    sleep 5
+                    def taskStatus = sh(
+                        script: 'make check-db-snapshot-task',
+                        returnStdout: true
+                    ).trim()
+                    echo "Task status is ${taskStatus}"
+                    if (taskStatus == 'FAILED') {
+                        sh("cf logs --recent db-snapshot")
+                        throw new Exception('Create db dump task failed')
                     }
-
-                  echo "Logged in to PaaS"
-
-                  sh('''
-                    cf create-service-key digitalmarketplace_api_db DATA_MIGRATION_KEY
-                    KEY_DATA=$(cf curl /v2/service_keys/$(cf service-key digitalmarketplace_api_db DATA_MIGRATION_KEY --guid))
-                    DB_HOST=$(echo $KEY_DATA | jq -r \'.entity.credentials.host\')
-                    DB_PASSWORD=$(echo $KEY_DATA | jq -r \'.entity.credentials.password\')
-                    DB_USERNAME=$(echo $KEY_DATA | jq -r \'.entity.credentials.username\')
-                    DB_NAME=$(echo $KEY_DATA | jq -r \'.entity.credentials.name\')
-                    cf ssh api -N -L 63306:$DB_HOST:5432 &
-                    SSH_PID=$!
-                    sleep 10
-                    OUTFILE_NAME=$(date +"%Y%m%d%H%M")
-                    pg_dump postgres://$DB_USERNAME:$DB_PASSWORD@localhost:63306/$DB_NAME --no-acl --no-owner | gzip | \
-                      openssl smime -encrypt -aes256 -binary -outform DEM -out ${OUTFILE_NAME}.gzip.ssl ${DM_CREDENTIALS_REPO}/jenkins-vars/db-dump-encryption-keypair/backup_key.pem.pub
-                    kill "$SSH_PID"
-                    cf delete-service-key -f digitalmarketplace_api_db DATA_MIGRATION_KEY
-                  ''')
-
-                  echo "Post dump generation"
-
+                    return (taskStatus == 'SUCCEEDED');
                   }
                 }
               }
-
-              stage('Upload to S3') {
-                echo "Starting upload"
-                dir('scripts') {
-                  git url: "git@github.com:alphagov/digitalmarketplace-scripts.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
-                  sh('''
-                    [ -d venv ] || virtualenv venv
-                    source ./venv/bin/activate
-                    pip install --upgrade pip
-                    pip install -r requirements.txt
-                    python ./scripts/upload-db-dump-to-s3.py preview "../aws/${OUTFILE_NAME}"
-                  ''')
-                }
-              }
-
-              stage('Cleanup') {
-                dir('aws') {
-                  rm ${OUTFILE_NAME}.gzip.ssl
-                }
-              }
-
-
             } catch(err) {
                 echo "Error caught"
-                dir('aws') {
-                  rm ${OUTFILE_NAME}.gzip.ssl
-                }
-                echo "Gonna clean the PaaS"
-                sh('make paas-clean')
                 currentBuild.result = 'FAILURE'
                 echo "Error: ${err}"
             } finally {
+              stage('Cleanup') {
+                sh('make cleanup-db-snapshot')
                 sh('make paas-clean')
+              }
             }
+          }
         }

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -2,7 +2,7 @@
     name: database-backup
     display-name: Create offsite backup of database
     project-type: pipeline
-    description: Takes a snapshot of the database, compresses it, encrypts it and uploads to S3.
+    description: Takes a dump of the database, compresses it, encrypts it and uploads to S3.
     disabled: false
     concurrent: true
     pipeline:
@@ -28,18 +28,18 @@
                   [ -d venv ] || virtualenv venv
                   . ./venv/bin/activate
                   pip install -r requirements.txt
-                  make preview deploy-db-snapshot
+                  make preview deploy-db-backup-app
                 ''')
                 timeout(2) {
                   waitUntil {
                     sleep 5
                     def taskStatus = sh(
-                        script: 'make check-db-snapshot-task',
+                        script: 'make check-db-backup-task',
                         returnStdout: true
                     ).trim()
                     echo "Task status is ${taskStatus}"
                     if (taskStatus == 'FAILED') {
-                        sh("cf logs --recent db-snapshot")
+                        sh("cf logs --recent db-backup")
                         throw new Exception('Create db dump task failed')
                     }
                     return (taskStatus == 'SUCCEEDED');
@@ -52,7 +52,7 @@
                 echo "Error: ${err}"
             } finally {
               stage('Cleanup') {
-                sh('make cleanup-db-snapshot')
+                sh('make cleanup-db-backup')
                 sh('make paas-clean')
               }
             }

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -30,16 +30,20 @@
         }
 
         node {
-        currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
-          withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=${STAGE}"]) {
+          currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
+
+          withEnv([
+            "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
+            "CF_HOME=${pwd()}",
+            "DUMP_FILE_NAME=${STAGE}-${new java.text.SimpleDateFormat('yyyyMMddHHmm').format(new Date())}.sql.gz.gpg"
+          ]) {
+
             try {
 
               stage('Prepare') {
+                echo "Getting ready to create ${DUMP_FILE_NAME}"
                 git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'
                 build job: "update-credentials"
-              }
-
-              stage('Login to Cloud Foundry') {
                 paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
                 withEnv(paas_credentials.tokenize("\n")) {
                   sh('make paas-login')
@@ -49,7 +53,7 @@
               stage('Connect to service, create dump and upload to S3') {
                 sh('''
                   make requirements
-                  make ${STAGE} deploy-db-backup-app
+                  DUMP_FILE_NAME=${DUMP_FILE_NAME} make ${STAGE} deploy-db-backup-app
                 ''')
                 timeout(10) {
                   waitUntil {
@@ -69,7 +73,7 @@
               }
 
               stage('Check decryption') {
-                sh('./scripts/check-db-dump-is-decryptable.sh')
+                sh('DUMP_FILE_NAME=${DUMP_FILE_NAME} ./scripts/check-db-dump-is-decryptable.sh')
                 notify_slack(':file_cabinet:', 'SUCCESS')
               }
 

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -18,6 +18,20 @@
             - production
     pipeline:
       script: |
+
+        def notify_slack(icon, status) {
+          build job: "notify-slack",
+                parameters: [
+                  string(name: 'USERNAME', value: "database-backup"),
+                  string(name: 'ICON', value: icon),
+                  string(name: 'JOB', value: "Backup ${STAGE} database to S3"),
+                  string(name: 'CHANNEL', value: "#dm-release"),
+                  text(name: 'STAGE', value: "${STAGE}"),
+                  text(name: 'STATUS', value: status),
+                  text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+                ]
+        }
+
         node {
           withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=${STAGE}"]) {
             try {
@@ -55,9 +69,11 @@
                     }
                     return (taskStatus == 'SUCCEEDED');
                   }
+                  notify_slack(':file_cabinet:', 'SUCCESS')
                 }
               }
             } catch(err) {
+                notify_slack(':-1:', 'FAILURE')
                 echo "Error caught"
                 currentBuild.result = 'FAILURE'
                 echo "Error: ${err}"

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -30,6 +30,7 @@
         }
 
         node {
+        currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
           withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=${STAGE}"]) {
             try {
               git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -4,11 +4,19 @@
     project-type: pipeline
     description: Takes a dump of the database, compresses it, encrypts it and uploads to S3.
     disabled: false
-    concurrent: true
+    concurrent: false
+    parameters:
+      - choice:
+          name: STAGE
+          choices:
+            - Select one
+            - preview
+            - staging
+            - production
     pipeline:
       script: |
         node {
-          withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=preview"]) {
+          withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}", "STAGE=${STAGE}"]) {
             try {
               git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'db_backups_from_live_db', credentialsId: 'github_com_and_enterprise'
 
@@ -28,7 +36,7 @@
                   [ -d venv ] || virtualenv venv
                   . ./venv/bin/activate
                   pip install -r requirements.txt
-                  make preview deploy-db-backup-app
+                  make ${STAGE} deploy-db-backup-app
                 ''')
                 timeout(10) {
                   waitUntil {

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -5,6 +5,9 @@
     description: Takes a dump of the database, compresses it, encrypts it and uploads to S3.
     disabled: false
     concurrent: false
+    triggers:
+      - parameterized-timer:
+          cron: "0 3 * * * % STAGE=preview"
     parameters:
       - choice:
           name: STAGE

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -48,9 +48,7 @@
 
               stage('Connect to service, create dump and upload to S3') {
                 sh('''
-                  [ -d venv ] || virtualenv venv
-                  . ./venv/bin/activate
-                  pip install -r requirements.txt
+                  make requirements
                   make ${STAGE} deploy-db-backup-app
                 ''')
                 timeout(10) {
@@ -76,7 +74,7 @@
               }
 
             } catch(err) {
-                notify_slack(':-1:', 'FAILURE')
+                notify_slack(':-1:', 'FAILED')
                 echo "Error caught"
                 currentBuild.result = 'FAILURE'
                 echo "Error: ${err}"

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -6,16 +6,13 @@
     disabled: false
     concurrent: false
     triggers:
-      - parameterized-timer:
-          cron: "0 3 * * * % STAGE=preview"
+      - timed: "0 3 * * *"
     parameters:
-      - choice:
+      - extended-choice:
           name: STAGE
-          choices:
-            - Select one
-            - preview
-            - staging
-            - production
+          type: radio
+          default-value: preview
+          value: preview,staging,production
     pipeline:
       script: |
 

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -11,7 +11,7 @@
       - extended-choice:
           name: STAGE
           type: radio
-          default-value: preview
+          default-value: production
           value: preview,staging,production
     pipeline:
       script: |

--- a/playbooks/roles/jenkins/files/gpg-agent.conf
+++ b/playbooks/roles/jenkins/files/gpg-agent.conf
@@ -1,0 +1,1 @@
+allow-loopback-pinentry

--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -76,6 +76,12 @@
 - name: Add AWS credentials file
   template: src=aws_credentials.j2 dest=/var/lib/jenkins/.aws/credentials
 
+- name: Add gpg-agent conf file
+  file: path=/var/lib/jenkins/.gnupg/gpg-agent.conf owner=jenkins group=jenkins
+
+- name: Kill gpg-agent
+  command: gpgconf --kill gpg-agent
+
 - name: Copy the NodeSource GPG key to the remote
   copy:
     src: ../files/nodesource.gpg.key


### PR DESCRIPTION
This job will deploy the db-backup app, which will create a dump for the live db, zip and encrypt it before uploading to S3.

At the moment it runs against the live db in whichever environment it's built. In future it should create a new postgres service from the latest snapshot taken by PaaS and then taken the dump from there. The logic for this is already in place (see this PR: https://github.com/alphagov/digitalmarketplace-aws/pull/315). This job can be updated when ready.

