### PR TITLE
Add GPG2 to list of tools

### DIFF
--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -31,6 +31,7 @@
     - xvfb
     - wkhtmltopdf
     - fonts-liberation
+    - gnupg2
 
 - name: Install rbenv and pyenv
   sudo: yes


### PR DESCRIPTION
We use GPG2 to encrpyt database backups. To make sure that the private
key in the creds repo and the public key being used to encrypt don't get
out of sync by mistake we're going to use GPG2 on jenkins to check the
encrypted files can be decryprted.