### PR TITLE
Use raw output from jq

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -88,7 +88,7 @@
 
               def stage_migrations_run_on = sh(
                 script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump/lastBuild/api/json | \
-                  jq '.actions[] | select(.parameters) | .parameters[] | select(.name == \"TARGET\") | .value'",
+                  jq -r '.actions[] | select(.parameters) | .parameters[] | select(.name == \"TARGET\") | .value'",
                 returnStdout: true
               ).trim()
 


### PR DESCRIPTION
Without specifying the `-r` flag to jq you get an extra set of quotes
around your return value. We don't want this as it breaks the
conditional later in the build stage.