### PR TITLE
notify_slack job: add a fallback plain text string for messages

### DIFF
--- a/job_definitions/notify_slack.yml
+++ b/job_definitions/notify_slack.yml
@@ -85,18 +85,20 @@
                   message.update({"text": TEXT})
                   return message
 
+              fields_def = (
+                  ("Project", PROJECT, False),
+                  ("Stage", STAGE, True),
+                  ("Release", RELEASE_NAME, True),
+                  ("Status", STATUS, True),
+                  ("Build URL", URL, True),
+              )
+
               message.update({
                   "text": "{} finished".format(JOB),
                   "attachments": [{
-                      "fallback": "{} ",
+                      "fallback": "\n".join("{}: {}".format(key, val) for key, val, short in fields_def),
                       "color": color_from_status(STATUS),
-                      "fields": build_fields([
-                          ("Project", PROJECT, False),
-                          ("Stage", STAGE, True),
-                          ("Release", RELEASE_NAME, True),
-                          ("Status", STATUS, True),
-                          ("Build URL", URL, True),
-                      ])
+                      "fields": build_fields(fields_def),
                   }],
               })
 


### PR DESCRIPTION
From the slack docs

```
fallback: A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
```

a "fallback" of `{} ` results in a bit of a fail for those of us who are sensible enough to run slack through an irc client.

*I'm not sure* if there's a way for me to test this prior to merging/shipping it...?