### PR TITLE
 Add a job to run get-model-data CSV exports

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -1,17 +1,18 @@
 - job:
-    name: build-app
-    display-name: Build application
+    name: build-image
+    display-name: Build Docker image
     project-type: pipeline
-    description: Builds the application artefact and uploads it to S3
+    description: Builds the docker image from a repository release tag
     disabled: false
     concurrent: true
     parameters:
       - choice:
-          name: APPLICATION_NAME
+          name: REPOSITORY
           choices:
 {% for application in dm_applications %}
             - {{ application }}
 {% endfor %}
+            - scripts
       - string:
           name: RELEASE_NAME
           description: "Application tag (eg 'release-42') to checkout for building the artefact"
@@ -24,8 +25,8 @@
         node {
             try {
                 stage('Check previous builds') {
-                  currentBuild.displayName = "#${BUILD_NUMBER} - ${APPLICATION_NAME} - ${RELEASE_NAME}"
-                  existingRelease = sh(script: "curl -fs https://index.docker.io/v1/repositories/digitalmarketplace/${APPLICATION_NAME}/tags/${RELEASE_NAME}", returnStatus: true)
+                  currentBuild.displayName = "#${BUILD_NUMBER} - ${REPOSITORY} - ${RELEASE_NAME}"
+                  existingRelease = sh(script: "curl -fs https://index.docker.io/v1/repositories/digitalmarketplace/${REPOSITORY}/tags/${RELEASE_NAME}", returnStatus: true)
                 }
 
                 if (existingRelease == 0 && (REBUILD.toString() == "false")) {
@@ -35,15 +36,15 @@
                 }
 
                 stage('Prepare') {
-                    git url: "git@github.com:alphagov/digitalmarketplace-${APPLICATION_NAME}.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+                    git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
                     echo "Cleaning repository"
                     sh("git clean -fdx")
                     echo "Checking out ${RELEASE_NAME}"
                     sh("git reset --hard ${RELEASE_NAME}")
                 }
                 stage('Build') {
-                    sh("docker build --pull -t digitalmarketplace/${APPLICATION_NAME} --build-arg release_name=${RELEASE_NAME} .")
-                    sh("docker tag digitalmarketplace/${APPLICATION_NAME} digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}")
+                    sh("docker build --pull -t digitalmarketplace/${REPOSITORY} --build-arg release_name=${RELEASE_NAME} .")
+                    sh("docker tag digitalmarketplace/${REPOSITORY} digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
                 }
                 stage('Upload') {
                     docker_credentials = sh(script: '/var/lib/jenkins/digitalmarketplace-credentials/sops-wrapper -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
@@ -51,8 +52,8 @@
                         sh("docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
                     }
 
-                    sh("docker push digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}")
-                    sh("docker push digitalmarketplace/${APPLICATION_NAME}:latest")
+                    sh("docker push digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
+                    sh("docker push digitalmarketplace/${REPOSITORY}:latest")
                 }
             } catch(err) {
                 currentBuild.result = 'FAILURE'

--- a/job_definitions/build_scripts.yml
+++ b/job_definitions/build_scripts.yml
@@ -1,0 +1,53 @@
+- job:
+    name: build-scripts
+    display-name: Build scripts
+    project-type: pipeline
+    description: Build the scripts Docker image and upload it to Docker Hub
+    disabled: false
+    concurrent: false
+    triggers:
+      - pollscm: "* * * * *"
+    pipeline:
+      script: |
+
+        def tag_release(tag) {
+          try {
+            sh("git config user.name 'Jenkins'")
+            sh("git config user.email '{{ jenkins_github_email }}'")
+            sh("git tag -a ${tag} -m ${tag}")
+            sh("git push origin ${tag} -f")
+          } catch(e) {
+            echo "${tag} tag already exists"
+          }
+        }
+
+        stage('Create release tag') {
+          node {
+            git url: "git@github.com:alphagov/digitalmarketplace-scripts.git",
+                branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+            releaseNumber = sh(
+                script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
+                returnStdout: true
+            ).trim()
+
+            if (releaseNumber == "") {
+                throw new Exception('Release number can not be found')
+            }
+
+            releaseName = "release-${releaseNumber}"
+
+            tag_release(releaseName)
+
+            echo "Release number: ${releaseNumber}"
+            currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
+          }
+        }
+
+        stage('Build') {
+          node {
+            build job: "build-image", parameters: [
+              string(name: "REPOSITORY", value: "scripts"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
+        }

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -67,7 +67,7 @@
               }
 
               stage('Apply data to target stage and google drive') {
-                sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_folder_id }}" make apply-cleaned-db-dump')
+                sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}" make apply-cleaned-db-dump')
               }
 
               stage('Check if migrations required and run'){

--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -1,0 +1,36 @@
+{% set environments = ['preview', 'production'] %}
+---
+{% for environment in environments %}
+- job:
+    name: "export-data-{{ environment }}"
+    display-name: "Export API model data as CSV - {{ environment }}"
+    project-type: freestyle
+    description: "Runs the get-model-data.py script and saves the generated CSV files to Google Drive"
+    triggers:
+      - timed: "H 3 * * 1"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=export-data
+              JOB=Export data {{ environment }}
+              ICON=:foi:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+
+          # We need to recreate the directory manually since the one created by Docker
+          # when mounting the volume will otherwise be owned by the root user.
+          rm -rf ./data && mkdir data
+
+          docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}"
+
+          {% if environment == "production" %}
+          /usr/local/bin/gdrive --config "/var/lib/jenkins/.gdrive" sync upload --delete-extraneous ./data "{{ jenkins_gdrive_csv_data_export_folder_id }}"
+          {% endif %}
+
+{% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -15,13 +15,6 @@
           name: FRAMEWORKS
           default: {{ frameworks }}
           description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8'). If no frameworks are specified then all currently published services will be indexed."
-    scm:
-      - git:
-          url: git@github.com:alphagov/digitalmarketplace-scripts.git
-          credentials-id: github_com_and_enterprise
-          branches:
-            - master
-          wipe-workspace: false
     triggers:
       - timed: "H 2 * * *"
     publishers:
@@ -38,10 +31,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
-          ./scripts/index-services.py '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}"
+          docker run digitalmarketplace/scripts scripts/index-services.py '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}"
 {% endfor %}

--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -83,8 +83,8 @@
 
         stage('Build') {
           node {
-            build job: "build-app", parameters: [
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            build job: "build-image", parameters: [
+              string(name: "REPOSITORY", value: "{{ application }}"),
               string(name: "RELEASE_NAME", value: "${releaseName}"),
             ]
           }

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -69,6 +69,8 @@ jenkins_list_views:
     jobs:
       - clean-and-apply-db-dump
       - database-backup
+      - export-data-preview
+      - export-data-production
       - index-services-preview
       - index-services-production
       - index-services-staging
@@ -86,6 +88,7 @@ jenkins_list_views:
       - apps-are-up-staging
   - name: "Utils and toolkit"
     jobs:
+      - build-scripts
       - publish-toolkit-documentation
       - tag-dmapiclient
       - tag-dmutils


### PR DESCRIPTION
Script is used to generate data analytics reports and save them as CSVs.

It's using the scripts docker container to run the script and maps a local folder as a volume to keep the reports in the workspace for uploading to Google Drive.

Since Jenkins is used to build the scripts Docker image it should always have the latest version available locally.

Job runs every Monday at 3am UTC.

### Add a job to build a scripts Docker image on each merge

Similar to the app deployment pipeline, we tag the scripts repo with a release tag and run the build image job. Since scripts aren't deployed anywhere that's all this job does.

### Rename build-app job to build-image

Jenkins "build application" job is used to build a Docker image from a tagged repository commit and upload it to Docker Hub.

Up until now it was only used to build application images, but the job isn't really tied to a deployment process, so it can be used to build any docker image. Renaming it to make this clear.