### PR TITLE
Alert slack if build image fails

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -58,6 +58,17 @@
             } catch(err) {
                 currentBuild.result = 'FAILURE'
                 echo "Error: ${err}"
+                build job: "notify-slack",
+                      parameters: [
+                        string(name: 'USERNAME', value: 'build-image'),
+                        string(name: 'ICON', value: ':rotating_light:'),
+                        string(name: 'JOB', value: "Build Docker image: ${REPOSITORY} - ${RELEASE_NAME}"),
+                        string(name: 'CHANNEL', value: "#dm-release"),
+                        string(name: 'PROJECT', value: "${REPOSITORY}"),
+                        text(name: 'RELEASE_NAME', value: "${RELEASE_NAME}"),
+                        text(name: 'STATUS', value: 'FAILED'),
+                        text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+                      ]
             } finally {
             }
         }

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -103,7 +103,7 @@
               notify_slack(':clean:', 'SUCCESS')
 
             } catch(err) {
-                notify_slack(':sadparrot:', 'FAILURE')
+                notify_slack(':sadparrot:', 'FAILED')
                 echo "Error caught"
                 currentBuild.result = 'FAILURE'
                 echo "Error: ${err}"


### PR DESCRIPTION
This is built on top of this: [https://github.com/alphagov/digitalmarketplace-jenkins/pull/23](https://github.com/alphagov/digitalmarketplace-jenkins/pull/23)

If an image fails to build it's not currently alerted. This pings the
dm-release channel so we can investigate quickly.