### PR TITLE
Rename default G-Cloud index to g-cloud-9

### DIFF
--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -1,6 +1,4 @@
-{% set environments = [('preview', 'g-cloud-9'), ('staging', 'g-cloud-9'), ('production', 'g-cloud-9')] %}
----
-{% for environment, frameworks in environments %}
+{% for environment in ['preview', 'staging', 'production'] %}
 - job:
     name: "index-services-{{ environment }}"
     display-name: "Index services - {{ environment }}"
@@ -9,11 +7,11 @@
     parameters:
       - string:
           name: INDEX
-          default: g-cloud
-          description: "Index name to use (eg 'g-cloud-2017-05-22')"
+          default: {{ search_config[environment].default_index }}
+          description: "Index name to use (eg 'g-cloud-9-2017-05-22')"
       - string:
           name: FRAMEWORKS
-          default: {{ frameworks }}
+          default: {{ search_config[environment].frameworks }}
           description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8'). If no frameworks are specified then all currently published services will be indexed."
     triggers:
       - timed: "H 2 * * *"

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -1,6 +1,4 @@
-{% set environments = ['preview', 'staging', 'production'] %}
----
-{% for environment in environments %}
+{% for environment in ['preview', 'staging', 'production'] %}
 - job:
     name: "update-{{ environment }}-index-alias"
     display-name: "Update {{ environment }} index alias"
@@ -10,7 +8,7 @@
     parameters:
       - string:
           name: ALIAS
-          default: g-cloud
+          default: {{ search_config[environment].default_index }}
           description: "The name of the alias you're applying."
       - string:
           name: TARGET

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -120,4 +120,15 @@ app_urls:
     search_api: https://search-api.digitalmarketplace.service.gov.uk
     www: https://www.digitalmarketplace.service.gov.uk
 
+search_config:
+  preview:
+    default_index: g-cloud-9
+    frameworks: g-cloud-9
+  staging:
+    default_index: g-cloud-9
+    frameworks: g-cloud-9
+  production:
+    default_index: g-cloud-9
+    frameworks: g-cloud-9
+
 jenkins_job_builder_pipeline_version: f24b9f5b0de03edd59b94061fa5182d11887403d


### PR DESCRIPTION
## Summary
Rename default index alias for G-Cloud services to the oldest live framework, in this case g-cloud-9. Pull out environments/default index/default framework to shared file for two jenkins jobs.