### PR TITLE
Update func tests to run in parallel

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -94,5 +94,5 @@
 
           export DM_ENVIRONMENT={{ job.environment }}
 
-          make run || make rerun
+          make run-parallel || make rerun
 {% endfor %}


### PR DESCRIPTION
There's a pull request in the functional tests repo
(https://github.com/alphagov/digitalmarketplace-functional-tests/pull/345/files)
to run the test suite in parallel. This updates the job to use the new
functionality.