### PR TITLE
Build report after running functional tests

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -94,5 +94,5 @@
 
           export DM_ENVIRONMENT={{ job.environment }}
 
-          make run-parallel || make rerun
+          make run-parallel && make build-report || ( make build-report; make rerun )
 {% endfor %}


### PR DESCRIPTION
As tests are being run in paralled they produce separate reports.
There's a make rule to combine them. This runs it after a successful or
unsuccessful run.