### PR TITLE
Get search index name from main.yml variables fil

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -1,42 +1,40 @@
+{% set environments = ['google-drive', 'preview', 'staging'] %}
+---
+{% for environment in environments %}
 - job:
-    name: clean-and-apply-db-dump
-    display-name: Clean and apply database dump
+    name: "clean-and-apply-db-dump-{{ environment }}"
+    display-name: "Clean and apply database dump - {{ environment }}"
     project-type: pipeline
-    description: Takes the latest production database dump, cleans it, and applies it to target stage. Also Google Drive.
+    description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also Google Drive."
     concurrent: false
+{% if environment == 'staging' %}
     triggers:
       - timed: "0 4 * * 0"
-    parameters:
-      - extended-choice:
-          name: TARGET
-          type: radio
-          default-value: staging
-          value: google-drive,preview,staging
+{% endif %}
     pipeline:
       script: |
 
         def notify_slack(icon, status) {
           build job: "notify-slack",
-                parameters: [
-                  string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
-                  string(name: 'ICON', value: icon),
-                  string(name: 'JOB', value: "Clean and apply database dump to ${TARGET}"),
-                  string(name: 'CHANNEL', value: "#dm-release"),
-                  text(name: 'STAGE', value: "${TARGET}"),
-                  text(name: 'STATUS', value: status),
-                  text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-                ]
+          parameters: [
+            string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
+            string(name: 'ICON', value: icon),
+            string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
+            string(name: 'CHANNEL', value: "#dm-release"),
+            text(name: 'STAGE', value: "{{ environment }}"),
+            text(name: 'STATUS', value: status),
+            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+          ]
         }
 
         node {
-          currentBuild.displayName = "#${BUILD_NUMBER} - ${TARGET}"
+          currentBuild.displayName = "#${BUILD_NUMBER} - {{ environment }}"
 
-            withEnv([
-              "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
-              "CF_HOME=${pwd()}",
-              "PAAS_SPACE=${TARGET}"
-            ]) {
-
+          withEnv([
+            "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
+            "CF_HOME=${pwd()}",
+            "PAAS_SPACE={{ environment }}"
+          ]) {
             try {
               stage('Prepare') {
                 git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
@@ -46,7 +44,7 @@
                   sh('make paas-login')
                 }
                 env.TARGET_ALEMBIC_VERSION = sh(
-                  script: "curl -s https://www.${TARGET}.marketplace.team/_status | jq -r '.api_status.db_version'",
+                  script: "curl -s https://www.{{ environment }}.marketplace.team/_status | jq -r '.api_status.db_version'",
                   returnStdout: true
                 )
               }
@@ -70,48 +68,49 @@
                 sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}" make apply-cleaned-db-dump')
               }
 
+{% if environment in ['preview', 'staging'] %}
               stage('Check if migrations required and run'){
-                if (("${TARGET}" == 'preview' || "${TARGET}" == 'staging') && (env.DUMP_ALEMBIC_VERSION != env.TARGET_ALEMBIC_VERSION)) {
+                if (env.DUMP_ALEMBIC_VERSION != env.TARGET_ALEMBIC_VERSION) {
                   build job: "database-migration-paas",
-                    parameters: [
-                      string(name: 'STAGE', value: "${TARGET}"),
-                      string(name: 'APPLICATION_NAME', value: 'api'),
-                      string(name: 'RELEASE_NAME', value: 'db-cleanup')
-                    ]
+                  parameters: [
+                    string(name: 'STAGE', value: "{{ environment }}"),
+                    string(name: 'APPLICATION_NAME', value: 'api'),
+                    string(name: 'RELEASE_NAME', value: 'db-cleanup')
+                  ]
                 }
               }
 
-              if ("${TARGET}" == 'preview' || "${TARGET}" == 'staging') {
-                withEnv(["INDEX_NAME=g-cloud-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
-                  stage('Index target stage'){
-                    build job: "index-services-${TARGET}",
-                      parameters: [
-                        string(name: 'INDEX', value: "${INDEX_NAME}"),
-                      ]
-                  }
-                  stage('Update index alias'){
-                    build job: "update-${TARGET}-index-alias",
-                      parameters: [
-                        string(name: 'ALIAS', value: 'g-cloud'),
-                        string(name: 'TARGET', value: "${INDEX_NAME}"),
-                        string(name: 'DELETE_OLD_INDEX', value: 'yes')
-                      ]
-                  }
+              withEnv(["INDEX_NAME={{ search_config[environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+                stage('Index target stage'){
+                  build job: "index-services-{{ environment }}",
+                  parameters: [
+                    string(name: 'INDEX', value: "${INDEX_NAME}"),
+                  ]
+                }
+                stage('Update index alias'){
+                  build job: "update-{{ environment }}-index-alias",
+                  parameters: [
+                    string(name: 'ALIAS', value: "{{ search_config[environment].default_index }}"),
+                    string(name: 'TARGET', value: "${INDEX_NAME}"),
+                    string(name: 'DELETE_OLD_INDEX', value: 'yes')
+                  ]
                 }
               }
+{% endif %}
 
               notify_slack(':clean:', 'SUCCESS')
 
             } catch(err) {
-                notify_slack(':sadparrot:', 'FAILED')
-                echo "Error caught"
-                currentBuild.result = 'FAILURE'
-                echo "Error: ${err}"
+              notify_slack(':sadparrot:', 'FAILED')
+              echo "Error caught"
+              currentBuild.result = 'FAILURE'
+              echo "Error: ${err}"
             } finally {
-                stage('Cleanup') {
-                  sh('make cleanup-postgres-container')
-                  sh('make paas-clean')
-                }
+              stage('Cleanup') {
+                sh('make cleanup-postgres-container')
+                sh('make paas-clean')
+              }
             }
           }
         }
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -68,7 +68,9 @@ build_monitor_jobs:
 jenkins_list_views:
   - name: "Data"
     jobs:
-      - clean-and-apply-db-dump
+      - clean-and-apply-db-dump-google-drive
+      - clean-and-apply-db-dump-preview
+      - clean-and-apply-db-dump-staging
       - database-backup
       - export-data-preview
       - export-data-production


### PR DESCRIPTION
## Summary
The `clean_and_apply_db_dump.yml` job has failed since we changed the name of the index from `g-cloud` to `g-cloud-9` and made this the precedent going forward. This script hardcoded `g-cloud` as the target index. Given that the index name is going to change when g-cloud-10 comes out, we'd like to simplify the process of updating this as much as possible. Other jobs in this repo make use of default values from `playbooks/roles/jenkins/defaults/main.yml`, and we currently store the default index name for G-Cloud indexing in it, so it makes sense to use that. However, those variables are used by Jinja templating and so are pre-populated into the jobs rather than available for dynamic assignment at runtime, so we'll need to change this job over to use templating. This will create three jobs (one each for g-drive, preview, and staging) rather than a single job which can target any stage. The old job ran every Sunday at 0400 with a default target of staging. This new file inserts the timed trigger for the staging job only, so we should get the same effect.

Also tweaked indenting.