### PR TITLE
Fix clean-and-apply-db-dump python3 errors

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -45,11 +45,16 @@
                 withEnv(paas_credentials.tokenize("\n")) {
                   sh('make paas-login')
                 }
+
                 env.TARGET_ALEMBIC_VERSION = sh(
-                  script: "curl -s https://www.{{ environment }}.marketplace.team/_status | jq -r '.api_status.db_version'",
+                  script: "curl -s https://api.{{ environment }}.marketplace.team/_status | jq -r '.db_version'",
                   returnStdout: true
                 )
 
+                env.TARGET_RELEASE_VERSION = sh(
+                  script: "curl -s https://api.{{ environment }}.marketplace.team/_status | jq -r '.version'",
+                  returnStdout: true
+                ).trim()
 {% endif %}
 
               }
@@ -81,7 +86,7 @@
                   parameters: [
                     string(name: 'STAGE', value: "{{ environment }}"),
                     string(name: 'APPLICATION_NAME', value: 'api'),
-                    string(name: 'RELEASE_NAME', value: 'db-cleanup')
+                    string(name: 'RELEASE_NAME', value: "${env.TARGET_RELEASE_VERSION}")
                   ]
                 }
               }

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -55,6 +55,7 @@
 
               stage('Import and clean lastest production db-dump') {
                 sh('''
+                  pyenv local 3.6.2
                   make requirements
                   make import-and-clean-db-dump
                 ''')

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -39,6 +39,8 @@
               stage('Prepare') {
                 git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
                 build job: "update-credentials"
+
+{% if environment in ['preview', 'staging'] %}
                 paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
                 withEnv(paas_credentials.tokenize("\n")) {
                   sh('make paas-login')
@@ -47,6 +49,9 @@
                   script: "curl -s https://www.{{ environment }}.marketplace.team/_status | jq -r '.api_status.db_version'",
                   returnStdout: true
                 )
+
+{% endif %}
+
               }
 
               stage('Run postgres container') {

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -76,7 +76,7 @@
               }
 
               stage('Apply data to target stage and google drive') {
-                sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}" make apply-cleaned-db-dump')
+                sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}" TARGET="{{ environment }}" make apply-cleaned-db-dump')
               }
 
 {% if environment in ['preview', 'staging'] %}
@@ -109,7 +109,7 @@
               }
 {% endif %}
 
-              notify_slack(':clean:', 'SUCCESS')
+              notify_slack(':shower:', 'SUCCESS')
 
             } catch(err) {
               notify_slack(':sadparrot:', 'FAILED')

--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -70,6 +70,9 @@
 - name: Install pyenv python
   shell: "sudo su jenkins -c 'source $HOME/.bash_profile && pyenv install -s 2.7.9 && pyenv global 2.7.9 && $HOME/.pyenv/shims/pip install virtualenv'"
 
+- name: Install pyenv python3
+  shell: "sudo su jenkins -c 'source $HOME/.bash_profile && pyenv install -s 3.6.2 && pyenv shell 3.6.2 && $HOME/.pyenv/shims/pip install virtualenv'"
+
 - name: Add .aws config directory
   file: path=/var/lib/jenkins/.aws state=directory owner=jenkins group=jenkins
 


### PR DESCRIPTION
Adds python3 environment to pyenv that can be used by the Jenkins jobs with `pyenv local 3.6.2`.

digitalmarketplace-aws is now using python3 to set up virtualenv, so we need to activate a Python 3 pyenv before installing requirements.

This requires hardcoding the python version in the job and any existing venvs will keep using the linked interpreter versions until the job workspace is manually cleaned.

For scripts we solved this by running them in a Docker container, but it's not clear whether this would be easy to do for aws repo, so I'm setting it up with pyenv for now.

## Other fixes

* There's no paas space called "gdrive-only" and we can skip PaaS login altogether since we're not going to restore to a PaaS environment.
* db-cleanup is not a valid release name, in order to apply the migrations that should've been applied to staging we need to know the API release version that's currently live on staging. Similar to the migration version we can get this from the API status endpoint output.
* `make apply-cleaned-db-dump` requires TARGET environment variable to be set. That variable was replaced with a Jinja variable when the jobs were split, so we need to explicitly set it for the make step.