### PR TITLE
Update all digitalmarketplace-aws jobs to Python 3

### DIFF
--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -52,6 +52,7 @@
 
               stage('Connect to service, create dump and upload to S3') {
                 sh('''
+                  pyenv local 3.6.2
                   make requirements
                   DUMP_FILE_NAME=${DUMP_FILE_NAME} make ${STAGE} deploy-db-backup-app
                 ''')

--- a/job_definitions/database_migration_paas.yml
+++ b/job_definitions/database_migration_paas.yml
@@ -30,7 +30,7 @@
                     build job: "update-credentials"
                     currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
                     sh('make paas-clean')
-                    sh('make requirements')
+                    sh('pyenv local 3.6.2 && make requirements')
                 }
 
                 stage('Run database migration') {

--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -49,7 +49,7 @@
                   build job: "update-credentials"
                   currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
                   sh('make paas-clean')
-                  sh('make requirements')
+                  sh('pyenv local 3.6.2 && make requirements')
               }
 
               stage('Deploy') {


### PR DESCRIPTION
Activates python3 pyenv before installing requirements on all jobs
that are calling `make requirements` for digitalmarketplace-aws.

From #31:

digitalmarketplace-aws is now using python3 to set up virtualenv,
so we need to activate a Python 3 pyenv before installing requirements.

This requires hardcoding the python version in the job and any existing
venvs will keep using the linked interpreter versions until the job
workspace is manually cleaned.

For scripts we solved this by running them in a Docker container, but
it's not clear whether this would be easy to do for aws repo, so I'm
setting it up with pyenv for now.