### PR TITLE
Fix incorrect call to jenkins clean db job

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -81,20 +81,19 @@
               }
 
             } catch(err) {
-              def migrations_being_run = sh(
-                script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump/lastBuild/api/json?tree=building | jq -r '.building'",
-                returnStdout: true
-              ).trim()
-
-              def stage_migrations_run_on = sh(
-                script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump/lastBuild/api/json | \
-                  jq -r '.actions[] | select(.parameters) | .parameters[] | select(.name == \"TARGET\") | .value'",
-                returnStdout: true
-              ).trim()
-
-              if (migrations_being_run == 'false' || (migrations_being_run == 'true' && stage_migrations_run_on != '{{ environment }}')) {
+              {% if environment == 'production' %}
                 notify_slack(':fire:', 'FAILED')
-              }
+              {% else %}
+                def migrations_being_run = sh(
+                  script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
+                  returnStdout: true
+                ).trim()
+
+                if (migrations_being_run == 'false') {
+                  notify_slack(':fire:', 'FAILED')
+                }
+              {% endif %}
+
               echo "Error caught"
               currentBuild.result = 'FAILURE'
               echo "Error: ${err}"


### PR DESCRIPTION
We were calling jenkins to see if a migration was currently
being run. The original call being made assumed there was an
underlying job for both of our clean and apply db dump jobs.
However, there is no underlying job and we instead have two jobs
which both have their environment in the name e.g.
`clean-and-apply-db-dump-staging`.

Because the url we were calling did not exist because no job existed
under this name, the response was an HTML 404 page. This then meant
that jq could not parse this as it was not JSON. Our shell script
therefore exited and no slack notifications were ever triggered.

To fix this, we can simply call the clean and apply dump job for
the appropriate environment (and therefore don't need to work out
which stage the dump is happening on). Note, as production
doesn't have a clean and apply db dump job, we never have a case
where we should not notify slack. Further note, that we need
to define our `migrations_being_run` function in the jinja
if statement so the function is not defined in production. This
is because the function is evaluated when the script is run rather
than afterwards when we make a potential call to it.

**Note, preview will not still not be alerting us until we run the first data dump script (has yet to been run on preview) - this PR will only fix STAGING and PRODUCTION.**