### PR TITLE
Add tasks to add dev's public keys to authorized_keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,7 @@ clean: ## Clean workspace (delete all generated files)
 .PHONY: jenkins
 jenkins: venv ## Run Jenkins playbook
 	$(if ${TAGS},,$(error Must specify a list of ansible tags in TAGS))
-	${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem.enc > ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem
-	chmod 600 ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem
 	ANSIBLE_CONFIG=playbooks/ansible.cfg ${VIRTUALENV_ROOT}/bin/ansible-playbook \
 		-i playbooks/hosts playbooks/jenkins_playbook.yml \
-		--private-key ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem \
 		-e @<(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/jenkins-vars/jenkins.yaml) \
 		--tags "${TAGS}" -e "jobs=${JOBS}"
-	rm ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem

--- a/playbooks/roles/jenkins/tasks/main.yml
+++ b/playbooks/roles/jenkins/tasks/main.yml
@@ -94,6 +94,23 @@
   with_items: jenkins_config_templates
   tags: config
 
+- name: Create temp authorized_keys file with shared public ssh key
+  copy: src=/{{ lookup('env', 'DM_CREDENTIALS_REPO') }}/aws-keys/ci.pub dest=/home/ubuntu/.ssh/authorized_keys_temp mode=600 owner=ubuntu group=ubuntu
+  tags: config
+
+- name: Add dev's public ssh keys to temp authorized_keys file
+  shell: >
+    curl -s https://api.github.com/users/{{ item.name }}/keys |
+    jq -r '.[] | select(.id=={{ item.key_id }}) | .key' |
+    awk '{print $0 " {{ item.name }}"}' >>
+    /home/ubuntu/.ssh/authorized_keys_temp
+  with_items: jenkins_github_users
+  tags: config
+
+- name: Replace authorized_keys with temp authorized_keys
+  command: mv /home/ubuntu/.ssh/authorized_keys_temp /home/ubuntu/.ssh/authorized_keys
+  tags: config
+
 - include: letsencrypt.yml tags=letsencrypt
 - include: nginx.yml tags=nginx
 - include: jobs.yml tags=jobs

--- a/playbooks/roles/jenkins/tasks/main.yml
+++ b/playbooks/roles/jenkins/tasks/main.yml
@@ -100,8 +100,10 @@
 
 - name: Add dev's public ssh keys to temp authorized_keys file
   shell: >
+    executable=/bin/bash
+    set -o pipefail &&
     curl -s https://api.github.com/users/{{ item.name }}/keys |
-    jq -r '.[] | select(.id=={{ item.key_id }}) | .key' |
+    jq -er '.[] | select(.id=={{ item.key_id }}) | .key' |
     awk '{print $0 " {{ item.name }}"}' >>
     /home/ubuntu/.ssh/authorized_keys_temp
   with_items: jenkins_github_users

--- a/playbooks/roles/jenkins/templates/jenkins/config.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/config.xml.j2
@@ -9,7 +9,7 @@
   <!-- GitHub usernames -->
 
   {% for user in jenkins_github_users %}
-    <permission>hudson.model.Hudson.Administer:{{ user }}</permission>
+    <permission>hudson.model.Hudson.Administer:{{ user.name }}</permission>
   {% endfor %}
 
     <!-- Jenkins Github user used for jenkins-job-builder -->


### PR DESCRIPTION
See this PR on the credentials repo which will need merging first: https://github.com/alphagov/digitalmarketplace-credentials/pull/22

The tasks will decrypt a list of dev's public keys which are in the
credentials repo and copy them to the ubuntu user's `authorized_keys`
fie, allowing devs to access Jenkins much more easily.

`authorized_keys` needs 600 permissions.

