### PR TITLE
Make sure job always notifies Slack for smoke test failures

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -84,12 +84,16 @@
               {% if environment == 'production' %}
                 notify_slack(':fire:', 'FAILED')
               {% else %}
-                def migrations_being_run = sh(
-                  script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
-                  returnStdout: true
-                ).trim()
+                try {
+                  def migrations_being_run = sh(
+                    script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
+                    returnStdout: true
+                  ).trim()
 
-                if (migrations_being_run == 'false') {
+                  if (migrations_being_run == 'false') {
+                    notify_slack(':fire:', 'FAILED')
+                  }
+                } catch(err) {
                   notify_slack(':fire:', 'FAILED')
                 }
               {% endif %}


### PR DESCRIPTION
## Summary
Catch error when checking if a migration is being run against an environment; no migration has been run against preview yet which is preventing the job failure from being announced in Slack.

## Ticket
https://trello.com/c/UGxgMEtW/16-smoke-test-failures-on-preview-arent-being-announced-on-slack