### PR TITLE
Rename nested error to prevent job runner failure

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -93,7 +93,7 @@
                   if (migrations_being_run == 'false') {
                     notify_slack(':fire:', 'FAILED')
                   }
-                } catch(err) {
+                } catch(err2) {
                   notify_slack(':fire:', 'FAILED')
                 }
               {% endif %}


### PR DESCRIPTION
Smoke tests are failing to run due to re-declaration of variable

Bug in implementation of https://github.com/alphagov/digitalmarketplace-jenkins/pull/37
```
Started by timer
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 68: The current scope already contains a variable of the name err
 @ line 68, column 11.
           } catch(err) {
             ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:958)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:554)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:129)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:123)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:516)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:479)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:268)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:415)
Finished: FAILURE
```