### PR TITLE
Run DB data CSV exports daily at 5am UTC

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -7,7 +7,7 @@
     project-type: freestyle
     description: "Runs the get-model-data.py script and saves the generated CSV files to Google Drive"
     triggers:
-      - timed: "H 3 * * 1"
+      - timed: "H 5 * * *"
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack


### PR DESCRIPTION
Moving the export to 5am so that it doesn't overlap with indexing or DB clean up on staging.