### PR TITLE
Fix typo on 4/8 weeks - string should be int

### DIFF
--- a/job_definitions/notify_buyers_to_award_closed_briefs.yml
+++ b/job_definitions/notify_buyers_to_award_closed_briefs.yml
@@ -1,7 +1,7 @@
 {% set environments = ['production'] %}
 {% set reminders = [
-    {"weeks": "4", "notify_template_id": "204d2bf5-5dd3-44c8-a68f-9111e040e831"},
-    {"weeks": "8", "notify_template_id": "bc1f93a8-9529-48b6-9a82-af61bc6da332"}
+    {"weeks": 4, "notify_template_id": "204d2bf5-5dd3-44c8-a68f-9111e040e831"},
+    {"weeks": 8, "notify_template_id": "bc1f93a8-9529-48b6-9a82-af61bc6da332"}
   ]
 %}
 ---


### PR DESCRIPTION
The final (final!) PR for the award email script ticket: https://trello.com/c/poIdAQc0/19-create-script-to-send-emails-to-buyers-with-recently-closed-briefs-at-scheduled-intervals

Specifying `"weeks": "4"` was giving an OFFSET_DAYS value of `4444444` thanks to Jinja's helpful templating syntax. (Insert pic of Homer Simpson saying "d'oh" here.)

The preview and production Jenkins jobs have the correct `OFFSET_DAYS` default already, this PR is just to tidy up and ensure we can recreate them correctly.