### PR TITLE
Conditionally create admin users for legacy func tests

### DIFF
--- a/job_definitions/functional_tests_legacy.yml
+++ b/job_definitions/functional_tests_legacy.yml
@@ -85,6 +85,8 @@
           mkdir -p reports
           rm -f screenshot*
 
+          ./scripts/create_users.sh example
+
           bundle exec cucumber features --tags ~@wip {% for tag in job.tags %} --tags {{ tag }} {% endfor %} --color --format html --out reports/index.html --format pretty
       - conditional-step:
           condition-kind: build-cause


### PR DESCRIPTION
The legacy functional tests require certain admin users to be set up.

The tests themselves don't do this.

If we wipe the preview db and restore from a cleaned version (as we do
with staging) we need to recreate those users. This is an annoying
manual chore.

Luckily we have a script to do this. Running it before the tests means
we don't have to remember to do this in the case of db restore.