### PR TITLE
Updated indexing jobs

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -91,7 +91,7 @@
                 }
               }
 
-              withEnv(["INDEX_NAME={{ search_config[environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+              withEnv(["INDEX_NAME={{ search_config['services'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
                 stage('Index target stage'){
                   build job: "index-services-{{ environment }}",
                   parameters: [
@@ -101,7 +101,24 @@
                 stage('Update index alias'){
                   build job: "update-{{ environment }}-index-alias",
                   parameters: [
-                    string(name: 'ALIAS', value: "{{ search_config[environment].default_index }}"),
+                    string(name: 'ALIAS', value: "{{ search_config['services'][environment].default_index }}"),
+                    string(name: 'TARGET', value: "${INDEX_NAME}"),
+                    string(name: 'DELETE_OLD_INDEX', value: 'yes')
+                  ]
+                }
+              }
+
+              withEnv(["INDEX_NAME={{ search_config['briefs'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+                stage('Index target stage'){
+                  build job: "index-briefs-{{ environment }}",
+                  parameters: [
+                    string(name: 'INDEX', value: "${INDEX_NAME}"),
+                  ]
+                }
+                stage('Update index alias'){
+                  build job: "update-{{ environment }}-index-alias",
+                  parameters: [
+                    string(name: 'ALIAS', value: "{{ search_config['briefs'][environment].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -18,7 +18,6 @@
             no frameworks are specified then all currently published briefs will be indexed.
       - string:
           name: CREATE_WITH_MAPPING
-          default:
           description: >
             Specify a mapping to create the index if it doesn't exist. If it does
             exist, the mapping for the index will be updated. There's no default here

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -1,0 +1,44 @@
+{% for environment in ['preview'] %}
+- job:
+    name: "index-briefs-{{ environment }}"
+    display-name: "Index briefs - {{ environment }}"
+    project-type: freestyle
+    description: "This imports all briefs (opportunities) in the current API database into the current Elasticsearch index."
+    parameters:
+      - string:
+          name: INDEX
+          default: {{ search_config['briefs'][environment].default_index }}
+          description: "Index name or alias to use (eg 'briefs-digital-outcomes-and-specialists')"
+      - string:
+          name: FRAMEWORKS
+          default: {{ search_config['briefs'][environment].frameworks }}
+          description: >
+            Comma-separated list of framework slugs that should be indexed
+            (eg 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2'). If
+            no frameworks are specified then all currently published briefs will be indexed.
+      - string:
+          name: CREATE_WITH_MAPPING
+          default:
+          description: >
+            Specify a mapping to create the index if it doesn't exist. If it does
+            exist, the mapping for the index will be updated. There's no default here
+            because using potentially-changed mappings should be done under manual control,
+            on a Production environment.
+    triggers:
+      - timed: "H 3 * * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=index-briefs
+              JOB=Index briefs {{ environment }} :jenkins_parrot:
+              ICON=:alarm_clock:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          docker run digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
+{% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -7,12 +7,20 @@
     parameters:
       - string:
           name: INDEX
-          default: {{ search_config[environment].default_index }}
-          description: "Index name to use (eg 'g-cloud-9-2017-05-22')"
+          default: {{ search_config['services'][environment].default_index }}
+          description: "Index name or alias to use (eg 'g-cloud-9-2017-05-22')"
       - string:
           name: FRAMEWORKS
-          default: {{ search_config[environment].frameworks }}
+          default: {{ search_config['services'][environment].frameworks }}
           description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8'). If no frameworks are specified then all currently published services will be indexed."
+      - string:
+          name: CREATE_WITH_MAPPING
+          default:
+          description: >
+            Specify a mapping to create the index if it doesn't exist. If it does
+            exist, the mapping for the index will be updated. There's no default here
+            because using potentially-changed mappings should be done under manual control,
+            on a Production environment.
     triggers:
       - timed: "H 2 * * *"
     publishers:
@@ -21,7 +29,7 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=index-services
-              JOB=Index services {{ environment }}
+              JOB=Index services {{ environment }} :jenkins_parrot:
               ICON=:alarm_clock:
               STAGE={{ environment }}
               STATUS=FAILED
@@ -29,5 +37,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run digitalmarketplace/scripts scripts/index-services.py '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}"
+          docker run digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -15,7 +15,6 @@
           description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8'). If no frameworks are specified then all currently published services will be indexed."
       - string:
           name: CREATE_WITH_MAPPING
-          default:
           description: >
             Specify a mapping to create the index if it doesn't exist. If it does
             exist, the mapping for the index will be updated. There's no default here

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -8,11 +8,14 @@
     parameters:
       - string:
           name: ALIAS
-          default: {{ search_config[environment].default_index }}
+          default:
           description: "The name of the alias you're applying."
       - string:
           name: TARGET
-          description: "The name of the index you're applying the alias to."
+          description: >
+            The name of the index you're applying the alias to, e.g.
+            '{{search_config['briefs'][environment].default_index}}' or
+            '{{search_config['services'][environment].default_index}}'.
       - extended-choice:
           name: DELETE_OLD_INDEX
           type: radio

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -78,6 +78,9 @@ jenkins_list_views:
       - index-services-preview
       - index-services-production
       - index-services-staging
+      - index-briefs-preview
+      - index-briefs-production
+      - index-briefs-staging
       - notify-buyers-when-requirements-close-preview
       - notify-buyers-when-requirements-close-production
       - snapshot-g7-stats-preview
@@ -148,14 +151,25 @@ app_urls:
     www: https://www.digitalmarketplace.service.gov.uk
 
 search_config:
-  preview:
-    default_index: g-cloud-9
-    frameworks: g-cloud-9
-  staging:
-    default_index: g-cloud-9
-    frameworks: g-cloud-9
-  production:
-    default_index: g-cloud-9
-    frameworks: g-cloud-9
+  briefs:
+    preview:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks:
+    staging:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks:
+    production:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks:
+  services:
+    preview:
+      default_index: g-cloud-9
+      frameworks: g-cloud-9
+    staging:
+      default_index: g-cloud-9
+      frameworks: g-cloud-9
+    production:
+      default_index: g-cloud-9
+      frameworks: g-cloud-9
 
 jenkins_job_builder_pipeline_version: f24b9f5b0de03edd59b94061fa5182d11887403d


### PR DESCRIPTION
Add new job for indexing briefs overnight, fix up services index job.
     - indexing briefs only to happen on preview for now;
     - services job was broken by script name change;
     - we need separate default parameters for the two jobs;
     - also add parameter to allow for new index creation, under manual control;
     - also update DB dump/import script to rebuild briefs index as well as services index;
     - 'update alias' job now cannot have a default alias/target, as it may be needed for both services and briefs. The description will contain some suggestions.
    
https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script

Needless to say I have no idea if this code actually works or not :/