### PR TITLE
Minor fix for jenkins indexing jobs

### DIFF
--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -11,7 +11,6 @@
           description: "Index name or alias to use (eg 'briefs-digital-outcomes-and-specialists')"
       - string:
           name: FRAMEWORKS
-          default: {{ search_config['briefs'][environment].frameworks }}
           description: >
             Comma-separated list of framework slugs that should be indexed
             (eg 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2'). If
@@ -22,7 +21,7 @@
             Specify a mapping to create the index if it doesn't exist. If it does
             exist, the mapping for the index will be updated. There's no default here
             because using potentially-changed mappings should be done under manual control,
-            on a Production environment.
+            on the Production environment.
     triggers:
       - timed: "H 3 * * *"
     publishers:

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -154,13 +154,10 @@ search_config:
   briefs:
     preview:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks:
     staging:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks:
     production:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks:
   services:
     preview:
       default_index: g-cloud-9


### PR DESCRIPTION
Remove default 'frameworks' for briefs index as jinja produced 'None'

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script