### PR TITLE
Add admin-manager and admin-framework-manager users to job configs

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -92,6 +92,12 @@
           export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_email }}"
           export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_password }}"
 
+          export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_manager_email }}"
+          export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_manager_password }}"
+
+          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
+          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
+
           export DM_PAGINATION_LIMIT=100
 
           export DM_ENVIRONMENT={{ job.environment }}

--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -69,6 +69,12 @@
                 export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
                 export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
 
+                export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_manager_email }}"
+                export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_manager_password }}"
+
+                export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
+                export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
+
                 export DM_PAGINATION_LIMIT=100
 
                 export DM_ENVIRONMENT={{ environment }}

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -71,6 +71,12 @@
           export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
           export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
 
+          export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
+          export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
+
+          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
+          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
+
           export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
           export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
 
@@ -88,6 +94,8 @@
             -e DM_PRODUCTION_ADMIN_USER_EMAIL -e DM_PRODUCTION_ADMIN_USER_PASSWORD \
             -e DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL -e DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD \
             -e DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL -e DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD \
+            -e DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL -e DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD \
+            -e DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
             digitalmarketplace/backstopjs:1.0.0 $COMMAND --configPath=config.js
 
       - conditional-step:


### PR DESCRIPTION
Make credentials available to functional tests, smoke tests and visual regression run.