### PR TITLE
clean_and_apply_db_dump: pass CREATE_WITH_MAPPING parameter to index-* jobs when triggering them

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -96,6 +96,7 @@
                   build job: "index-services-{{ environment }}",
                   parameters: [
                     string(name: 'INDEX', value: "${INDEX_NAME}"),
+                    string(name: 'CREATE_WITH_MAPPING', value: "{{ search_config['services'][environment].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){
@@ -113,6 +114,7 @@
                   build job: "index-briefs-{{ environment }}",
                   parameters: [
                     string(name: 'INDEX', value: "${INDEX_NAME}"),
+                    string(name: 'CREATE_WITH_MAPPING', value: "{{ search_config['briefs'][environment].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -153,19 +153,25 @@ search_config:
   briefs:
     preview:
       default_index: briefs-digital-outcomes-and-specialists
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
     staging:
       default_index: briefs-digital-outcomes-and-specialists
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
     production:
       default_index: briefs-digital-outcomes-and-specialists
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
     preview:
       default_index: g-cloud-9
       frameworks: g-cloud-9
+      default_mapping_name: services
     staging:
       default_index: g-cloud-9
       frameworks: g-cloud-9
+      default_mapping_name: services
     production:
       default_index: g-cloud-9
       frameworks: g-cloud-9
+      default_mapping_name: services
 
 jenkins_job_builder_pipeline_version: f24b9f5b0de03edd59b94061fa5182d11887403d


### PR DESCRIPTION
Seeing as this particular job wants to create a new index each time this would appear to be needed.

Have pushed an experimental version of this to jenkins expected to run tonight (or rather, the morning of the 2017-12-05).