### PR TITLE
Update some notify jobs to use docker/py3

### DIFF
--- a/job_definitions/notify_buyers_when_requirements_close.yml
+++ b/job_definitions/notify_buyers_when_requirements_close.yml
@@ -37,11 +37,6 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
           if [ -n "$DATE_CLOSED" ]; then
             FLAGS="--date-closed=$DATE_CLOSED"
           fi
@@ -50,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          ./scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --email-api-key="$MANDRILL_API_KEY_{{ environment|upper }}" $FLAGS
+          docker run digitalmarketplace/scripts scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --email-api-key="$MANDRILL_API_KEY_{{ environment|upper }}" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -1,6 +1,9 @@
+{% set environments = ['production'] %}
+---
+{% for environment in environments %}
 - job:
-    name: "notify-suppliers-of-dos-opportunities-production"
-    display-name: "Notify suppliers of DOS opportunities - production"
+    name: "notify-suppliers-of-dos-opportunities-{{ environment }}"
+    display-name: "Notify suppliers of DOS opportunities - {{ environment }}"
     project-type: freestyle
     description: "Create and send mailchimp campaign to suppliers for the latest Digital Outcomes and Specialists opportunities"
     parameters:
@@ -14,7 +17,9 @@
       - choice:
           name: MAILCHIMP_LIST_ID
           choices:
+            {% if environment == "production" %}
             - production-list
+            {% endif %}
             - test-list
           description: "To send the email to the briefs team instead of production users then choose 'test-list'"
       - choice:
@@ -39,19 +44,14 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=dos-opportunities
-              JOB=Notify suppliers of the latest DOS opportunities - production
+              JOB=Notify suppliers of the latest DOS opportunities - {{ environment }}
               ICON=:briefs:
-              STAGE=production
+              STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
           if [ "$MAILCHIMP_LIST_ID" = "test-list" ]; then
             FLAGS="--list_id=096e52cebb"
           fi
@@ -64,4 +64,5 @@
             FLAGS="$FLAGS --number_of_days=$NUMBER_OF_DAYS"
           fi
 
-          ./scripts/send_dos_opportunities_email.py "production" "$DM_DATA_API_TOKEN_PRODUCTION" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+          docker run digitalmarketplace/scripts scripts/send_dos_opportunities_email.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+{% endfor %}

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -37,11 +37,6 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
           if [ -n "$SUPPLIER_IDS" ]; then
             FLAGS="--supplier-ids=$SUPPLIER_IDS"
           fi
@@ -50,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          ./scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $DM_DATA_API_TOKEN_{{ environment|upper }} $MANDRILL_API_KEY_{{ environment|upper }} $FLAGS
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $DM_DATA_API_TOKEN_{{ environment|upper }} $MANDRILL_API_KEY_{{ environment|upper }} $FLAGS
 {% endfor %}


### PR DESCRIPTION
Story https://trello.com/c/pCNtBX6A/108-converting-jenkins-jobs-to-python-3

Also environment-parametrized `notify_suppliers_of_dos_opportunities`: though we're only actually adding a job for the "production" environment here, it is occasionally useful to be able to spawn up a job that will draw its data from preview or staging.

Omitting `update_index_alias` for now as it looks like that will need a few changes to the script to be able to operate without requiring the presence of `digitalmarketplace-credentials` and all its dependencies. Or the answer might be to make _all_ the scripts depend on `digitalmarketplace-credentials`. Who knows.

All of these have been pushed to jenkins with positive results.