### PR TITLE
Reorganise plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ docker run digitalmarketplace/scripts scripts/my-amazing-script.py arg1 arg2 ...
 This removes the need for activating a virtualenv or installing requirements with pip.
 
 [More information on running scripts with Docker](https://github.com/alphagov/digitalmarketplace-scripts#running-scripts-with-docker)
+
+
+## Plugins
+
+The list of plugins in `/playbooks/roles/jenkins/defaults/main.yml` should reflect the list at https://ci.marketplace.team/pluginManager/installed (dependencies
+are greyed out on the dashboard, and are not included in the `main.yml` list).
+
+To upgrade a plugin (for example, to address a security vulnerability), tick the relevant box on the Updates panel of the plugins dashboard, and
+ click `Download now and install after restart` and follow the instructions given.
+
+ Jenkins should restart during a quiet period when no jobs are running (the restart will take a few seconds).

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -30,9 +30,11 @@ dm_db_applications:
 
 jenkins_plugins:
   - ansicolor
+  - blueocean
   - build-monitor-plugin
   - build-name-setter
   - conditional-buildstep
+  - cvs
   - extended-choice-parameter
   - git
   - github
@@ -43,6 +45,10 @@ jenkins_plugins:
   - nodejs
   - parameterized-trigger
   - postbuildscript
+  - rebuild
+  - translation
+  - workflow-aggregator  # aka 'Pipeline' suite
+  - ws-cleanup
 
 jenkins_config_templates:
   - config.xml

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -29,20 +29,20 @@ dm_db_applications:
   - api
 
 jenkins_plugins:
+  - ansicolor
+  - build-monitor-plugin
+  - build-name-setter
+  - conditional-buildstep
+  - extended-choice-parameter
   - git
   - github
   - github-oauth
-  - conditional-buildstep
+  - greenballs
+  - htmlpublisher
+  - lockable-resources
+  - nodejs
   - parameterized-trigger
   - postbuildscript
-  - build-monitor-plugin
-  - nodejs
-  - ansicolor
-  - htmlpublisher
-  - greenballs
-  - build-name-setter
-  - extended-choice-parameter
-  - lockable-resources
 
 jenkins_config_templates:
   - config.xml


### PR DESCRIPTION
The plugin list on the Ansible config did not match reality of the dashboard.

- Alphabetise the list so we can easily see missing plugins and update with the missing ones
- Add some info to the README about updating plugins

NB: I haven't checked whether we actually **use** all of these! We should do a proper plugin audit at a later date.