### PR TITLE
Update upload DOS suppliers email list job to use py3

### DIFF
--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -26,9 +26,4 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
-          ./scripts/upload_dos_opportunities_email_list.py "production" "$DM_DATA_API_TOKEN_PRODUCTION" "jenkins" "$MAILCHIMP_API_TOKEN"
+          docker run digitalmarketplace/scripts scripts/upload_dos_opportunities_email_list.py "production" "$DM_DATA_API_TOKEN_PRODUCTION" "jenkins" "$MAILCHIMP_API_TOKEN"


### PR DESCRIPTION
Update this job to use python 3 (We caught failures due to incompatibilities in future module between py2 and py3).
* Update upload DOS suppliers email list job to use py3  