### PR TITLE
Remove redundant virtualenv/pip install from Publish Manual job

### DIFF
--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -14,8 +14,4 @@
       - pollscm: "H/2 * * * *"
     builders:
       - shell: |
-          [ -x /tmp/dm-manual-venv/bin/pip ] || virtualenv /tmp/dm-manual-venv
-          . /tmp/dm-manual-venv/bin/activate
-
-          pip install -r requirements.txt
           make clean html pages


### PR DESCRIPTION
The manual's `make html` command now creates and applies its own virtualenv, and installs 
 requirements. See https://github.com/alphagov/digitalmarketplace-manual/pull/46 for details.