### PR TITLE
Use dockerised script for snapshot stats

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -12,13 +12,6 @@
     logrotate:
       daysToKeep: 20
       artifactDaysToKeep: 20
-    scm:
-      - git:
-          url: git@github.com:alphagov/digitalmarketplace-api.git
-          credentials-id: github_com_and_enterprise
-          branches:
-            - master
-          wipe-workspace: false
     triggers:
       - timed: "H * * * *"
     publishers:
@@ -35,11 +28,6 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
-          ./scripts/snapshot_framework_stats.py {{ framework }} {{ environment }} "$DM_DATA_API_TOKEN_{{ environment|upper }}"
+          docker run digitalmarketplace/scripts scripts/snapshot-framework-stats.py "{{ framework }}" "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}"
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary
Use snapshot-framework-stats scripts through docker now that it's moved from dm-api to dm-scripts

## Corresponding PRs
https://github.com/alphagov/digitalmarketplace-scripts/pull/187
https://github.com/alphagov/digitalmarketplace-api/pull/733

## Ticket
https://trello.com/c/mtiS5IAx/3-move-scripts-running-python-2-on-jenkins-to-python3-docker