### PR TITLE
Use docker scripts

### DIFF
--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -14,13 +14,6 @@
     logrotate:
       daysToKeep: 20
       artifactDaysToKeep: 20
-    scm:
-      - git:
-          url: git@github.com:alphagov/digitalmarketplace-scripts.git
-          credentials-id: github_com_and_enterprise
-          branches:
-            - master
-          wipe-workspace: false
     triggers:
       - timed: {{ schedule }}
     publishers:
@@ -37,12 +30,7 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          [ -d venv ] || virtualenv venv
-
-          . ./venv/bin/activate
-          pip install -r requirements.txt
-
-          python ./scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} "$DM_DATA_API_TOKEN_{{ environment|upper }}" {{ performance_platform_bearer_token }} --{{ period }}
+          docker run digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} "$DM_DATA_API_TOKEN_{{ environment|upper }}" {{ performance_platform_bearer_token }} --{{ period }}
 
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary
Use our dm-scripts docker container to ship framework application stats to the performance platform.

## Ticket
https://trello.com/c/mtiS5IAx/3-move-scripts-running-python-2-on-jenkins-to-python3-docker