### PR TITLE
Dockerize framework app stats export

### DIFF
--- a/job_definitions/export_framework_applicant_details.yml
+++ b/job_definitions/export_framework_applicant_details.yml
@@ -11,13 +11,6 @@
         <p>This exports 'About You' and lot details for suppliers who applied to {{ framework }}.</p>
         <p>Running this job will create a timestamped csv file in the <b>SCRIPT_OUTPUTS</b> folder
            in the workspace for this job.</p>
-      scm:
-        - git:
-            url: git@github.com:alphagov/digitalmarketplace-scripts.git
-            credentials-id: github_com_and_enterprise
-            branches:
-              - master
-            wipe-workspace: false
       publishers:
         - trigger-parameterized-builds:
             - project: notify-slack
@@ -32,11 +25,6 @@
                 CHANNEL=#dm-development
       builders:
         - shell: |
-            [ -d venv ] || virtualenv venv
-
-            . ./venv/bin/activate
-            pip install -r requirements.txt
-
-            ./scripts/export-framework-applicant-details.py {{ environment }} $DM_DATA_API_TOKEN_{{ environment|upper }} {{ framework }} SCRIPT_OUTPUTS
+            docker run digitalmarketplace/scripts scripts/export-framework-applicant-details.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "{{ framework }}" "SCRIPT_OUTPUTS"
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary
Use dockerized dm-scripts for framework application stats export. This script already appears compatible with Python3.

## Ticket
https://trello.com/c/mtiS5IAx/3-move-scripts-running-python-2-on-jenkins-to-python3-docker
