### PR TITLE
Jenkins job to notify suppliers of awarded briefs (preview/prod)

### DIFF
--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -1,0 +1,52 @@
+{% set environments = ['preview', 'production'] %}
+{% set NOTIFY_TEMPLATE_ID = '7379f74f-3f51-4b50-950c-d86b7880e999' %}
+---
+{% for environment in environments %}
+- job:
+    name: "notify-suppliers-of-awarded-briefs-{{ environment }}"
+    display-name: "Notify suppliers that a brief they applied to has been awarded - {{ environment }}"
+    project-type: freestyle
+    description: "Send email notifications to supplier users if they have a completed application to a brief that has been awarded."
+    parameters:
+      - string:
+          name: AWARDED_AT
+          default: null
+          description: "Specify a given date, send emails for briefs awarded on that date (format: YYYY-MM-DD)"
+      - string:
+          name: BRIEF_RESPONSE_IDS
+          default: null
+          description: "List of BriefResponse IDs to be emailed (e.g. following a failure)"
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "List notifications that would be sent without sending the emails"
+    triggers:
+      - timed: "H 8 * * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=supplier-brief-awards
+              JOB=Notify suppliers of brief awards {{ environment }}
+              ICON=:crystal_ball:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          if [ -n "AWARDED_AT" ]; then
+            FLAGS="--awarded_at=AWARDED_AT"
+          fi
+
+          if [ -n "BRIEF_RESPONSE_IDS" ]; then
+            FLAGS="$FLAGS --brief_response_ids=BRIEF_RESPONSE_IDS"
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-awarded-briefs.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}" $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $FLAGS --verbose
+{% endfor %}

--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -15,7 +15,7 @@
       - string:
           name: BRIEF_RESPONSE_IDS
           default: null
-          description: "List of BriefResponse IDs to be emailed (e.g. following a failure)"
+          description: "Comma-separated list of BriefResponse IDs to be emailed (e.g. '1234,5678')"
       - bool:
           name: DRY_RUN
           default: false

--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -36,12 +36,12 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          if [ -n "AWARDED_AT" ]; then
-            FLAGS="--awarded_at=AWARDED_AT"
+          if [ -n "$AWARDED_AT" ]; then
+            FLAGS="--awarded_at=$AWARDED_AT"
           fi
 
-          if [ -n "BRIEF_RESPONSE_IDS" ]; then
-            FLAGS="$FLAGS --brief_response_ids=BRIEF_RESPONSE_IDS"
+          if [ -n "$BRIEF_RESPONSE_IDS" ]; then
+            FLAGS="$FLAGS --brief_response_ids=$BRIEF_RESPONSE_IDS"
           fi
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -108,6 +108,8 @@ jenkins_list_views:
       - notify-buyers-to-award-closed-briefs-8-weeks-production
       - notify-buyers-when-requirements-close-preview
       - notify-buyers-when-requirements-close-production
+      - notify-suppliers-of-awarded-briefs-preview
+      - notify-suppliers-of-awarded-briefs-production
       - notify-suppliers-of-dos-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-preview


### PR DESCRIPTION
Trello: https://trello.com/c/LsEbL3jP/306-send-dos-suppliers-an-email-to-let-them-know-the-outcome

Adds the Jenkins jobs for preview/production to send notifications to suppliers for briefs that have been awarded. There are optional parameters for:
- `dry-run`: log what would happen, without sending emails
- `brief_response_ids`: send emails only to suppliers for those specific BriefResponse IDs (for re-running failures)
- `awarded_at`: send emails for briefs awarded on a specific date (e.g. if a job failed to run over the weekend) 

Also adds the new jobs to the 'Emails' tab in Jenkins.