### PR TITLE
Update script names

### DIFF
--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -64,5 +64,5 @@
             FLAGS="$FLAGS --number_of_days=$NUMBER_OF_DAYS"
           fi
 
-          docker run digitalmarketplace/scripts scripts/send_dos_opportunities_email.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+          docker run digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -26,4 +26,4 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run digitalmarketplace/scripts scripts/upload_dos_opportunities_email_list.py "production" "$DM_DATA_API_TOKEN_PRODUCTION" "jenkins" "$MAILCHIMP_API_TOKEN"
+          docker run digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "$DM_DATA_API_TOKEN_PRODUCTION" "jenkins" "$MAILCHIMP_API_TOKEN"


### PR DESCRIPTION
## Summary
Update script names after https://github.com/alphagov/digitalmarketplace-scripts/pull/197. As long as both of these PRs get merged in the afternoon, there should be no issue as these two jobs run in the morning.

## Scripts PR
https://github.com/alphagov/digitalmarketplace-scripts/pull/197

## Ticket
https://trello.com/c/3Ca1I5m6/152-script-filenames-to-use-instead-of-in-scripts-repo