### PR TITLE
Add new 'dm-test-utils' lib for automatic tagging of new versions.

### DIFF
--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -1,4 +1,4 @@
-{% set packages = ['utils', 'apiclient', 'content-loader'] %}
+{% set packages = ['utils', 'apiclient', 'content-loader', 'test-utils'] %}
 ---
 {% for package in packages %}
 - job:


### PR DESCRIPTION
We have a new library; new versions of it should be tagged in git like the others.

https://trello.com/c/lQIP4rf8/300-flash-messages-briefs-app