### PR TITLE
Disable clean-and-apply-db-dump job

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -6,6 +6,7 @@
     display-name: "Clean and apply database dump - {{ environment }}"
     project-type: pipeline
     description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also Google Drive."
+    disabled: true
     concurrent: false
 {% if environment == 'staging' %}
     triggers:


### PR DESCRIPTION
We don't want it to run while the pen testers are in.