### PR TITLE
Pin cf-cli version to v6.32.0

### DIFF
--- a/playbooks/roles/jenkins/tasks/paas.yml
+++ b/playbooks/roles/jenkins/tasks/paas.yml
@@ -2,7 +2,7 @@
 
 - name: Download CloudFoundry Debian package
   get_url:
-    url: "https://cli.run.pivotal.io/stable?release=debian64&source=github"
+    url: "https://packages.cloudfoundry.org/stable?release=debian64&version=6.32.0&source=github-rel"
     dest: /tmp/cloudfoundry-cli.deb
   register: download_result
 


### PR DESCRIPTION
An issue with version 6.34.0 (see https://github.com/cloudfoundry/cli/issues/1325#issuecomment-367979659) caused our API DB migration job to fail.

Pinning to an older version of the CLI without this issue fixes this.