### PR TITLE
Remove pipeline timeout

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -34,20 +34,19 @@
               }
             } catch(error) {
               echo "Functional tests failed: ${error}"
-              timeout(time:1, unit:'DAYS') {
-                script {
-                  env.FAILED_TEST_ACTION = input message: 'Functional tests failed. Retry, skip or abort?',
-                    parameters: [
-                      [
-                        $class: 'ChoiceParameterDefinition',
-                        choices: 'Retry\nSkip',
-                        description: 'Failed functional tests action',
-                        name: 'action'
-                      ]
+              script {
+                env.FAILED_TEST_ACTION = input message: 'Functional tests failed. Retry, skip or abort?',
+                  parameters: [
+                    [
+                      $class: 'ChoiceParameterDefinition',
+                      choices: 'Retry\nSkip',
+                      description: 'Failed functional tests action',
+                      name: 'action'
                     ]
-                }
-                echo "Action chosen was ${env.FAILED_TEST_ACTION}"
+                  ]
               }
+              echo "Action chosen was ${env.FAILED_TEST_ACTION}"
+
               if (env.FAILED_TEST_ACTION == 'Retry') {
                 echo "Retrying functional tests on ${stage}."
                 return false
@@ -81,20 +80,18 @@
             } else {
               echo "Visual regression tests build result: ${vr_job_result}"
 
-              timeout(time:1, unit:'DAYS') {
-                script {
-                  env.FAILED_TEST_ACTION = input message: 'Visual regression tests failed. Retry, approve, bypass?', parameters: [
-                    [
-                      $class: 'ChoiceParameterDefinition',
-                      choices: 'Retry\nApprove\nBypass',
-                      description: 'Failed visual regression tests action',
-                      name: 'action'
-                    ]
+              script {
+                env.FAILED_TEST_ACTION = input message: 'Visual regression tests failed. Retry, approve, bypass?', parameters: [
+                  [
+                    $class: 'ChoiceParameterDefinition',
+                    choices: 'Retry\nApprove\nBypass',
+                    description: 'Failed visual regression tests action',
+                    name: 'action'
                   ]
-                }
-
-                echo "Action chosen was ${env.FAILED_TEST_ACTION}"
+                ]
               }
+
+              echo "Action chosen was ${env.FAILED_TEST_ACTION}"
 
               if (env.FAILED_TEST_ACTION == 'Retry') {
                 echo "Retrying visual regression tests on ${stage}."


### PR DESCRIPTION
  ## Summary
Removes the 24-hour pipeline timeout from deployment jobs. This seems to
have only caused problems in reality. I'm not sure what the original
intent was behind the jobs dying but I think it was related to not
having executors blocked by paused jobs. I don't think this is the case,
and if it theoretically were, we'd encounter it anyway when we pause
before deploy to staging.

@Wynndow is there a reason for this we aren't aware of?