### PR TITLE
Add jenkins job for notifying suppliers

### DIFF
--- a/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
+++ b/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
@@ -1,0 +1,47 @@
+{% set environments = ['production'] %}
+---
+{% for environment in environments %}
+- job:
+    name: "notify-suppliers-whether-application-made-for-framework-{{ environment }}"
+    display-name: "Notify suppliers whether application made for framework - {{ environment }}"
+    project-type: freestyle
+    description: "Send email notifications to supplier users indicating whether or not they completed an application for a framework."
+    disabled: true
+    parameters:
+      - bool:
+          name: DRY_RUN
+          default: true
+          description: "List notifications that would be sent without sending the emails"
+      - string:
+          name: FRAMEWORK_SLUG
+          description: "The framework slug for which applications have just closed (e.g. g-cloud-10)."
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: SUCCESS
+            predefined-parameters: |
+              USERNAME=${FRAMEWORK_SLUG}-applications
+              JOB=Notify suppliers whether application made for framework - {{ environment }}
+              ICON=:successkid:
+              STAGE={{ environment }}
+              STATUS=SUCCESS
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=${FRAMEWORK_SLUG}-applications
+              JOB=Notify suppliers whether application made for framework - {{ environment }}
+              ICON=:question:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-whether-application-made-for-framework.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "$FRAMEWORK_SLUG" "$NOTIFY_API_TOKEN" $FLAGS
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -141,6 +141,9 @@ jenkins_list_views:
       - release-user-frontend
       - database-migration-paas
       - release-app-paas
+  - name: "Framework lifecycle jobs"
+    jobs:
+      - notify-suppliers-whether-application-made-for-framework-production
 
 app_urls:
   preview:


### PR DESCRIPTION
 ## Summary
When applications for a framework close, we need to email all supplier
users to indicate whether or not they made a successful application for
the framework. We have a script that sends these emails that has
historically been run on a developer's machine. Since this script can
run for a long time, ideally it should run somewhere else, so this adds
a Jenkins job that will run the script.

 ## Ticket
https://trello.com/c/pgCNeI7P/126