### PR TITLE
Disable stats to performance platform

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -1,5 +1,5 @@
 {% set environments = ['preview', 'production'] %}
-{% set frameworks = [('g-cloud-10', 'false')] %}
+{% set frameworks = [('g-cloud-10', 'true')] %}
 ---
 {% for environment in environments %}
 {% for framework, disabled in frameworks %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,5 +1,5 @@
 {% set environments = ['production'] %}
-{% set frameworks = [('g-cloud-10', 'false')] %}
+{% set frameworks = [('g-cloud-10', 'true')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}


### PR DESCRIPTION
 ## Summary
G-Cloud 10 applications are now closed so we no longer need to snapshot
stats and send them to the Performance Platform.