### PR TITLE
Remove Jenkins aws config file

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -28,7 +28,7 @@
           rm -rf ./data && mkdir data
 
           docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}"
-          docker run --user $(id -u) -e "AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile {{ environment }})" -e "AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile {{ environment }})" --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv opportunity-data.csv --public
+          docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv opportunity-data.csv --public
 
           {% if environment == "production" %}
           /usr/local/bin/gdrive --config "/var/lib/jenkins/.gdrive" sync upload --delete-extraneous ./data "{{ jenkins_gdrive_csv_data_export_folder_id }}"

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -67,7 +67,7 @@
                   sh('source ./venv/bin/activate')
                   sh('pip install --upgrade pip')
                   sh('pip install -r requirements.txt')
-                  sh('AWS_PROFILE="{{ environment }}" python ./scripts/upload-counterpart-agreements.py \
+                  sh('python ./scripts/upload-counterpart-agreements.py \
                   {{ environment }} \
                   "$DM_DATA_API_TOKEN_{{ environment|upper }}" \
                   generated-countersignature-pdfs \

--- a/job_definitions/publish_g_cloud_services.yml
+++ b/job_definitions/publish_g_cloud_services.yml
@@ -36,5 +36,5 @@
           . ./venv/bin/activate
           pip install -r requirements.txt
 
-          AWS_PROFILE="{{ environment }}" python ./scripts/make-g-cloud-live.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }}
+          python ./scripts/make-g-cloud-live.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }}
 {% endfor %}

--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -73,12 +73,6 @@
 - name: Install pyenv python3
   shell: "sudo su jenkins -c 'source $HOME/.bash_profile && pyenv install -s 3.6.2 && pyenv shell 3.6.2 && $HOME/.pyenv/shims/pip install virtualenv'"
 
-- name: Add .aws config directory
-  file: path=/var/lib/jenkins/.aws state=directory owner=jenkins group=jenkins
-
-- name: Add AWS credentials file
-  template: src=aws_credentials.j2 dest=/var/lib/jenkins/.aws/credentials
-
 - name: Add gpg-agent conf file
   file: path=/var/lib/jenkins/.gnupg/gpg-agent.conf owner=jenkins group=jenkins
 

--- a/playbooks/roles/jenkins/templates/aws_credentials.j2
+++ b/playbooks/roles/jenkins/templates/aws_credentials.j2
@@ -1,5 +1,0 @@
-{% for stage in jenkins_aws_api_credentials %}
-[{{ stage }}]
-aws_access_key_id = {{ jenkins_aws_api_credentials[stage].key }}
-aws_secret_access_key = {{ jenkins_aws_api_credentials[stage].secret }}
-{% endfor %}


### PR DESCRIPTION
We had three scripts which were using an aws config file for
credentials. The credentials in the file belonged to a user called
`deploy` which was a hangover from when we used ElasticBeanstalk. That
user has quite a lot of permissions and we should probably get rid of
them.

The Jenkins box has its own credentials by way of an instance profile.
If we need Jenkins to interact with AWS we should probably just give
this instance profile (the role 'jenkins') the correct permissions,
rather than maintaining two different credentials.

There's a PR up on the AWS repo to adjust the jenkins role policy to
allow these extra permissions for reading/writing to certain S3 buckets.