### PR TITLE
Revert "Disable clean-and-apply-db-dump job"

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -6,7 +6,6 @@
     display-name: "Clean and apply database dump - {{ environment }}"
     project-type: pipeline
     description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also Google Drive."
-    disabled: true
     concurrent: false
 {% if environment == 'staging' %}
     triggers:


### PR DESCRIPTION
Only the 'preview' version of this job is actually run automatically on a schedule, the others are for ad-hoc use.

This reverts commit 1546b650dea5ada5f76dfb60f5c35df1957f98a4.