### PR TITLE
Remove quotes from `$FLAGS`

### DIFF
--- a/job_definitions/publish_dos_draft_services.yml
+++ b/job_definitions/publish_dos_draft_services.yml
@@ -32,5 +32,5 @@
             FLAGS="--dry-run"
           fi
 
-          docker run digitalmarketplace/scripts ./scripts/publish-dos-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} "$FLAGS"
+          docker run digitalmarketplace/scripts ./scripts/publish-dos-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} $FLAGS
 {% endfor %}

--- a/job_definitions/publish_g_cloud_draft_services.yml
+++ b/job_definitions/publish_g_cloud_draft_services.yml
@@ -32,5 +32,5 @@
             FLAGS="--dry-run"
           fi
 
-          docker run digitalmarketplace/scripts ./scripts/publish-g-cloud-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }} "$FLAGS"
+          docker run digitalmarketplace/scripts ./scripts/publish-g-cloud-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }} $FLAGS
 {% endfor %}


### PR DESCRIPTION
When `dry-run` is not set, it expands to ''. Which breaks the script.