### PR TITLE
Update jenkins jobs for scripts that use get_auth_token

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -27,7 +27,7 @@
           # when mounting the volume will otherwise be owned by the root user.
           rm -rf ./data && mkdir data
 
-          docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}"
+          docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}'
           docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv opportunity-data.csv --public
 
           {% if environment == "production" %}

--- a/job_definitions/export_framework_applicant_details.yml
+++ b/job_definitions/export_framework_applicant_details.yml
@@ -25,6 +25,6 @@
                 CHANNEL=#dm-development
       builders:
         - shell: |
-            docker run digitalmarketplace/scripts scripts/export-framework-applicant-details.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "{{ framework }}" "SCRIPT_OUTPUTS"
+            docker run digitalmarketplace/scripts scripts/export-framework-applicant-details.py "{{ environment }}" "{{ framework }}" "SCRIPT_OUTPUTS"
 {% endfor %}
 {% endfor %}

--- a/job_definitions/notify_buyers_to_award_closed_briefs.yml
+++ b/job_definitions/notify_buyers_to_award_closed_briefs.yml
@@ -70,6 +70,6 @@
             FLAGS="$FLAGS --buyer-ids=$BUYER_IDS"
           fi
 
-          docker run digitalmarketplace/scripts scripts/notify-buyers-to-award-closed-briefs.py {{ environment }} $DM_DATA_API_TOKEN_{{ environment|upper }} $NOTIFY_API_TOKEN $NOTIFY_TEMPLATE_ID $FLAGS
+          docker run digitalmarketplace/scripts scripts/notify-buyers-to-award-closed-briefs.py {{ environment }} $NOTIFY_API_TOKEN $NOTIFY_TEMPLATE_ID $FLAGS
 {% endfor %}
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -48,5 +48,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-awarded-briefs.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}" $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $FLAGS --verbose
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-awarded-briefs.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $FLAGS --verbose
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_brief_withdrawals.yml
+++ b/job_definitions/notify_suppliers_of_brief_withdrawals.yml
@@ -49,5 +49,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-brief-withdrawal.py '{{ environment }}' "$DM_DATA_API_TOKEN_{{ environment|upper }}" $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $PARAMS $FLAGS --verbose
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-brief-withdrawal.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $PARAMS $FLAGS --verbose
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -64,5 +64,5 @@
             FLAGS="$FLAGS --number_of_days=$NUMBER_OF_DAYS"
           fi
 
-          docker run digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+          docker run digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -45,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $DM_DATA_API_TOKEN_{{ environment|upper }} $MANDRILL_API_KEY_{{ environment|upper }} $FLAGS
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $MANDRILL_API_KEY_{{ environment|upper }} $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
+++ b/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
@@ -43,5 +43,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run digitalmarketplace/scripts scripts/notify-suppliers-whether-application-made-for-framework.py "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}" "$FRAMEWORK_SLUG" "$NOTIFY_API_TOKEN" $FLAGS
+          docker run digitalmarketplace/scripts scripts/notify-suppliers-whether-application-made-for-framework.py "{{ environment }}" "$FRAMEWORK_SLUG" "$NOTIFY_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/publish_dos_draft_services.yml
+++ b/job_definitions/publish_dos_draft_services.yml
@@ -32,5 +32,5 @@
             FLAGS="--dry-run"
           fi
 
-          docker run digitalmarketplace/scripts ./scripts/publish-dos-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} $FLAGS
+          docker run digitalmarketplace/scripts ./scripts/publish-dos-draft-services.py $FRAMEWORK "{{ environment }}" $FLAGS
 {% endfor %}

--- a/job_definitions/publish_g_cloud_draft_services.yml
+++ b/job_definitions/publish_g_cloud_draft_services.yml
@@ -32,5 +32,5 @@
             FLAGS="--dry-run"
           fi
 
-          docker run digitalmarketplace/scripts ./scripts/publish-g-cloud-draft-services.py $FRAMEWORK "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }} $FLAGS
+          docker run digitalmarketplace/scripts ./scripts/publish-g-cloud-draft-services.py $FRAMEWORK "{{ environment }}" digitalmarketplace-submissions-production-production digitalmarketplace-documents-{{ environment }}-{{ environment }} $FLAGS
 {% endfor %}

--- a/job_definitions/scan_g_cloud_services_for_bad_words.yml
+++ b/job_definitions/scan_g_cloud_services_for_bad_words.yml
@@ -41,5 +41,5 @@
           rm -rf ./data && mkdir data
           cp ./blacklist.txt ./data/blacklist.txt
 
-          docker run --volume $(pwd)/data:/app/data digitalmarketplace/scripts ./scripts/scan-g-cloud-services-for-bad-words.py "{{ environment }}" $DM_DATA_API_TOKEN_{{ environment|upper }} /app/data/blacklist.txt $FRAMEWORK /app/data
+          docker run --volume $(pwd)/data:/app/data digitalmarketplace/scripts ./scripts/scan-g-cloud-services-for-bad-words.py "{{ environment }}" /app/data/blacklist.txt $FRAMEWORK /app/data
 {% endfor %}

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -28,6 +28,6 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run digitalmarketplace/scripts scripts/snapshot-framework-stats.py "{{ framework }}" "{{ environment }}" "$DM_DATA_API_TOKEN_{{ environment|upper }}"
+          docker run digitalmarketplace/scripts scripts/snapshot-framework-stats.py "{{ framework }}" "{{ environment }}"
 {% endfor %}
 {% endfor %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -30,7 +30,7 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} "$DM_DATA_API_TOKEN_{{ environment|upper }}" {{ performance_platform_bearer_token }} {{ pp_service }} --{{ period }}
+          docker run digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_token }} {{ pp_service }} --{{ period }}
 
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
In PR https://github.com/alphagov/digitalmarketplace-scripts/pull/244 script parameters were changed so that the api token is no longer a command line argument.

This PR changes the Jenkins jobs to reflect this change.