### PR TITLE
stats_to_performance_platform: enable for dos3, change credentials format

### DIFF
--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -30,7 +30,7 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_token }} {{ pp_service }} --{{ period }}
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_tokens[pp_service] }} {{ pp_service }} --{{ period }}
 
 {% endfor %}
 {% endfor %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,5 +1,5 @@
 {% set environments = ['production'] %}
-{% set frameworks = [('digital-outcomes-and-specialists-3', 'digital-outcomes-specialists', 'true')] %}
+{% set frameworks = [('digital-outcomes-and-specialists-3', 'digital-outcomes-specialists', 'false')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}


### PR DESCRIPTION
We now fetch the pp bearer token out of a per-`pp_service` dictionary, named `performance_platform_bearer_tokens`. Expect a PR to the credentials repo mirroring this soon.

We seem to be being provided with a new bearer token for each `pp_service` so we'll need to do this in case we're needed to have >1 framework open at once.