### PR TITLE
Use environment vars for API tokens instead of script args

### DIFF
--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -38,5 +38,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -36,5 +36,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --search-api-token="$DM_SEARCH_API_TOKEN_{{ environment|upper }}" --api-token="$DM_DATA_API_TOKEN_{{ environment|upper }}" --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
 {% endfor %}


### PR DESCRIPTION
Trello: https://trello.com/c/XJEqu5gI/15-spike-audit-tokens-used-by-jenkins-jobs

The `index-to-search-service.py` script is already set up to check for environment vars. Use these instead of script args to avoid logging credentials in the Jenkins console.

Have tested this for indexing briefs on Preview, works fine.

(Missed this one in the last PR, whoops!)