### PR TITLE
Upgrade jenkins job builder

### DIFF
--- a/playbooks/roles/jenkins/tasks/jobs.yml
+++ b/playbooks/roles/jenkins/tasks/jobs.yml
@@ -7,8 +7,8 @@
   copy:
     content: |
       python-jenkins==0.4.15  # newer ones have broken basic auth :(
-      jenkins-job-builder==1.6.2
-      git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline
+      jenkins-job-builder==2.2.1
+      git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@c8aac16b97eb89882e0a5a7250ad8ed33ca7ddd8#egg=jenkins_job_builder_pipeline
     dest: /tmp/jenkins-jobs-python-requirements.txt
     force: yes
 


### PR DESCRIPTION
We need the newest version of Jenkins Job Builder to use the `lockable-resources` job description syntax:

@katstevens 
> Aha! https://github.com/openstack-infra/jenkins-job-builder/commit/7f275c323652b707770ec145a351d953536d11e0#diff-36bdcd4f77806e60b5005d2ad15d858f - v2.0.0
That’s why lockable-resources doesn’t work