### PR TITLE
Upgrade Ansible to v2.6.2 (vulnerability and bug fixes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.5.2
+ansible==2.6.2


### PR DESCRIPTION
Trello: https://trello.com/c/SQFTqKxQ/395-jenkins-vulnerability-upgrade-ansible-to-262

Addresses a long running Snyk vulnerability alert 🎉 

The version bump also includes some bugfixes, see changelog: 
https://github.com/ansible/ansible/blob/stable-2.6/changelogs/CHANGELOG-v2.6.rst

Tested this locally running `make jenkins TAGS=sops` (a noop).