### PR TITLE
Use new Jenkins user api token for smoke tests

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -92,7 +92,7 @@
               {% else %}
                 try {
                   def migrations_being_run = sh(
-                    script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_token }}@ci3.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
+                    script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@ci3.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
                     returnStdout: true
                   ).trim()
 


### PR DESCRIPTION
Trello: https://trello.com/c/kAcfiH2s/416-smoke-tests-notifying-slack-of-failures-during-migrations-when-they-should-ignore-them

If the smoke tests fail, the job should check whether a DB cleanup is happening or not before sending a Slack alert. The `curl` request to check this was using the old `jenkins_api_token` which is being deprecated, so the curl gave an authentication error, which meant the slack alert got sent when it shouldn't have.

Running the curl request with the new token works locally.
