### PR TITLE
Stop credentials from being echoed into logs

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -63,6 +63,8 @@
           rbenv install -s
           gem install bundler --conservative
 
+          set +x # do not echo credentials - remove for debugging
+
           export DM_API_DOMAIN="{{ app_urls[job.environment].data_api }}"
           export DM_API_ACCESS_TOKEN="$DM_DATA_API_TOKEN_{{ job.environment|upper }}"
 
@@ -94,6 +96,8 @@
 
           export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
           export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
+
+          set -x # restore echo
 
           export DM_PAGINATION_LIMIT=100
 

--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -45,6 +45,8 @@
                 rbenv install -s
                 gem install bundler --conservative
 
+                set +x # do not echo credentials - remove for debugging
+
                 export DM_API_DOMAIN="{{ app_urls[environment].data_api }}"
                 export DM_API_ACCESS_TOKEN="$DM_DATA_API_TOKEN_{{ environment|upper }}"
 
@@ -74,6 +76,8 @@
 
                 export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
                 export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
+
+                set -x # restore echo
 
                 export DM_PAGINATION_LIMIT=100
 

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -57,6 +57,9 @@
       - shell: |
 
           export DM_ENVIRONMENT="{{ environment }}"
+
+          set +x # do not echo credentials - remove for debugging
+
           export DM_FRONTEND_DOMAIN="{{ app_urls[environment].www }}"
 
           export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
@@ -79,6 +82,8 @@
 
           export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
           export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
+
+          set -x # restore echo
 
           curl ${DM_FRONTEND_DOMAIN}/_status
           curl ${DM_FRONTEND_DOMAIN}/buyers/_status


### PR DESCRIPTION
Ticket: https://trello.com/c/eBl3yUUT/27-jenkins-credentials-shown-in-plain-text-in-job-scripts-and-logs

@katstevens and @lfdebrux are going through Jenkins jobs and making fixes to jobs where currently they are echoing secrets.