### PR TITLE
Email jobs shouldn't be in Jenkins 'data' list

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -88,8 +88,6 @@ jenkins_list_views:
       - index-briefs-preview
       - index-briefs-production
       - index-briefs-staging
-      - notify-buyers-when-requirements-close-preview
-      - notify-buyers-when-requirements-close-production
       - snapshot-g7-stats-preview
       - snapshot-g7-stats-production
       - update-preview-index-alias


### PR DESCRIPTION
Noticed during the Jenkins credentials audit. Both jobs are already in the 'emails' list, where they should be.