### PR TITLE
Update host to ci.marketplace.team

### DIFF
--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,5 +1,5 @@
 [jenkins]
-ci3.marketplace.team
+ci.marketplace.team
 
 [jenkins:vars]
 ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
For [this trello ticket](https://trello.com/c/jgDcpfh3)

Using ci3 was weird, so Jenkins has moved back to ci.marketplace.team