### PR TITLE
Use localhost in smoke tests check

### DIFF
--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -96,7 +96,7 @@
               {% else %}
                 try {
                   def migrations_being_run = sh(
-                    script: "curl -s https://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@ci3.marketplace.team/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
+                    script: "curl -s http://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@localhost:80/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
                     returnStdout: true
                   ).trim()
 


### PR DESCRIPTION
By using localhost rather than the full DNS url we don't have to worry
about making sure the subdomain is correct.

Have tested this by ssh'ing into jenkins and running the curl.