### PR TITLE
Hide GDRIVE export var from console output

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -79,7 +79,15 @@
               }
 
               stage('Apply data to target stage and google drive') {
-                sh('GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}" TARGET="{{ environment }}" make apply-cleaned-db-dump')
+                sh(
+                   script: '''
+                     set +x
+                     export GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}"
+                     set -x
+                     export TARGET="{{ environment }}"
+                     make apply-cleaned-db-dump
+                   '''
+                  )
               }
 
 {% if environment in ['preview', 'staging'] %}


### PR DESCRIPTION
Trello https://trello.com/c/eBl3yUUT/27-jenkins-credentials-shown-in-plain-text-in-job-scripts-and-logs

Use `set +x` to hide the `GDRIVE_EXPORTDATA_FOLDER_ID` from Jenkins console output.

Tested here: https://ci.marketplace.team/view/Data/job/clean-and-apply-db-dump-google-drive/15/console