### PR TITLE
Add `copy_old_builds.sh` to playbook

### DIFF
--- a/playbooks/roles/jenkins/files/copy_old_builds.sh
+++ b/playbooks/roles/jenkins/files/copy_old_builds.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+for d in {release-*,functional-tests-*,visual-regression-*,build-image,database-migration-paas,tag-application-deloyment,clean-and-apply-db-dump-*,index-services-*,index-briefs-*,update-*-index-alias,data-retention-*,database-backup,rotate-api-tokens,rotate-production-notify-callback-token}/; do
+    rsync -vazh -e "ssh -i ~/.ssh/<private key to use>" --progress --include 'builds**' --include 'last*' --include 'nextBuildNumber' --exclude '*' jenkins@<source instance host>:/data/jenkins/jobs/"$d" /data/jenkins/jobs/"$d"
+done

--- a/playbooks/roles/jenkins/tasks/main.yml
+++ b/playbooks/roles/jenkins/tasks/main.yml
@@ -13,6 +13,8 @@
   tags: [plugins]
 - import_tasks: config.yml  # must come after plugins, otherwise we are configuring plugins that are not installed!
   tags: [config]
+- import_tasks: scripts.yml
+  tags: [scripts]
 - import_tasks: gdrive.yml
   tags: [gdrive]
 - import_tasks: docker.yml

--- a/playbooks/roles/jenkins/tasks/scripts.yml
+++ b/playbooks/roles/jenkins/tasks/scripts.yml
@@ -1,0 +1,3 @@
+---
+- name: Copy script for transfering old builds from outgoing server
+  copy: src=copy_old_builds.sh dest=/data/jenkins/jobs owner=jenkins mode=0700


### PR DESCRIPTION
If we're creating a new Jenkins box we're probably going to want to copy
the old builds from the outgoing box. There's a dead simple script to do
this using rsync. We can add it to the Jenkins build so it's available
without having to add it to the box later.

To use it, the ssh key being used will need filling in, as well the
hostname of the old server.

There didn't seem to be a great place to add this script copy, so I
created a new task. It needs to be run after the config task as this is
where the jenkins data directory is created with permissions.