### PR TITLE
Remove requirement on virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ requirements: venv ## Install requirements
 venv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
 
 ${VIRTUALENV_ROOT}/activate:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: clean
 clean: ## Clean workspace (delete all generated files)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To run a script with Python3 inside a Docker container, call the script as follo
 docker run digitalmarketplace/scripts scripts/my-amazing-script.py arg1 arg2 ...
 ```
 
-This removes the need for activating a virtualenv or installing requirements with pip.
+This removes the need for activating a venv or installing requirements with pip.
 
 [More information on running scripts with Docker](https://github.com/alphagov/digitalmarketplace-scripts#running-scripts-with-docker)
 


### PR DESCRIPTION
Python36 includes the venv module which means we no longer need virtualenv to be installed on the development system