### PR TITLE
New jobs to disambiguate the role of creating and updating indexes

### DIFF
--- a/job_definitions/create_index.yml
+++ b/job_definitions/create_index.yml
@@ -51,5 +51,9 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --serial --index="${INDEX_NAME}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${MAPPING}"
+          if [ "$SERIAL" = "true" ]; then
+            FLAGS="--serial"
+          fi
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX_NAME}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${MAPPING}" $FLAGS
 {% endfor %}

--- a/job_definitions/create_index.yml
+++ b/job_definitions/create_index.yml
@@ -1,0 +1,55 @@
+{% for environment in ['preview', 'staging', 'production'] %}
+- job:
+    name: "create-index-{{ environment }}"
+    display-name: "Create index - {{ environment }}"
+    project-type: freestyle
+    description: >
+      This job creates a new index in the ElasticSearch service from specified objects in the database.
+
+      Visiting either https://search-api.<STAGE>.marketplace.team/_status or
+      https://search-api.digitalmarketplace.service.gov.uk/_status will show you currently available indexes and their
+      aliases.
+
+      You can use the above to get an idea of naming conventions.
+
+      Once you have created your new index you might want to use it on the site. To do so, you can give your new index
+      an 'alias' here https://ci.marketplace.team/job/update-{{ environment }}-index-alias/
+    parameters:
+      - choice:
+          name: OBJECTS
+          choices:
+            - briefs
+            - services
+      - string:
+          name: INDEX_NAME
+          description: "A new name for your new index (eg 'g-cloud-9-2017-05-22', 'briefs-digital-outcomes-and-specialists-2017-05-22')"
+      - string:
+          name: FRAMEWORKS
+          description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8', 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2'). If no frameworks are specified then all currently published services will be indexed."
+      - string:
+          name: MAPPING
+          description: >
+            This mapping is a filename (without .json suffix) which should exist in the
+            digitalmarketplace-search-api/mappings directory
+            (https://github.com/alphagov/digitalmarketplace-search-api/tree/master/mappings)
+            (eg 'services', 'services-g-cloud-10', 'briefs-digital-outcomes-and-specialists-2')
+      - bool:
+          name: SERIAL
+          default: true
+          description: "Perform a non-parallel indexing. Turn this on for clearer debugging."
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=create-index
+              JOB=Index services {{ environment }} :jenkins_parrot:
+              ICON=:alarm_clock:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --serial --index="${INDEX_NAME}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${MAPPING}"
+{% endfor %}

--- a/job_definitions/update_index.yml
+++ b/job_definitions/update_index.yml
@@ -33,6 +33,10 @@
           description: >
             Comma-separated list of framework slugs that should be indexed
             (eg 'g-cloud-10' or 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2').
+      - bool:
+          name: SERIAL
+          default: true
+          description: "Perform a non-parallel indexing. Turn this on for clearer debugging."
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack
@@ -47,5 +51,9 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}"
+          if [ "$SERIAL" = "true" ]; then
+            FLAGS="--serial"
+          fi
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX}" --frameworks="${FRAMEWORKS}" $FLAGS
 {% endfor %}

--- a/job_definitions/update_index.yml
+++ b/job_definitions/update_index.yml
@@ -1,0 +1,51 @@
+{% for environment in ['preview', 'staging', 'production'] %}
+- job:
+    name: "update-index-{{ environment }}"
+    display-name: "Update index - {{ environment }}"
+    project-type: freestyle
+    description: >
+      This job updates an existing ElasticSearch index with services or briefs as they exist in the database
+
+      In all likelihood you want to reindex all existing briefs or services to their corresponding index.
+
+      Visiting either https://search-api.<STAGE>.marketplace.team/_status or
+      https://search-api.digitalmarketplace.service.gov.uk/_status will show you currently available indexes and their
+      aliases.
+
+      To reindex all briefs your object will be 'briefs', the index will be 'briefs-digital-outcomes-and-specialists'
+      and the frameworks should be 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2'
+
+      To reindex the g-cloud services list the object is 'services', the index is 'g-cloud-10' and the frameworks would
+      be 'g-cloud-10'
+
+      However you may be testing a new index and want to input its name and frameworks manually.
+    parameters:
+      - choice:
+          name: OBJECTS
+          choices:
+            - briefs
+            - services
+      - string:
+          name: INDEX
+          description: "The current name or alias of the index you want to update (briefs-digital-outcomes-and-specialists or g-cloud-10)"
+      - string:
+          name: FRAMEWORKS
+          description: >
+            Comma-separated list of framework slugs that should be indexed
+            (eg 'g-cloud-10' or 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2').
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=update-index
+              JOB=Update index - {{ environment }} :jenkins_parrot:
+              ICON=:alarm_clock:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}"
+{% endfor %}


### PR DESCRIPTION
After chatting to @Wynndow  this morning, I think a lot of the difficulty in understanding what the various index jobs are for came from the fact that the `index_services` and `index_briefs` jobs did almost exactly the same thing. But crucially both behave very differently when you specify the `CREATE_WITH_MAPPING` param. In that case instead of updating an existing index they create a new one

There's quite a big cognitive distance between creating and updating an index. And the situations in which you'd want to perform those actions are also pretty different.

This PR has a couple of new jobs for Jenkins split along the lines of `create_index` and `update_index` rather than what objects they're operating on.


I'd add them in parallel then we can remove the usage of the old ones once these are tested.