### PR TITLE
Give briefs indexing job default frameworks

### DIFF
--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -11,10 +11,10 @@
           description: "Index name or alias to use (eg 'briefs-digital-outcomes-and-specialists')"
       - string:
           name: FRAMEWORKS
+          default: {{ search_config['briefs'][environment].frameworks }}
           description: >
             Comma-separated list of framework slugs that should be indexed
-            (eg 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2'). If
-            no frameworks are specified then all currently published briefs will be indexed.
+            (eg 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2').
       - string:
           name: CREATE_WITH_MAPPING
           description: >

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -174,12 +174,15 @@ search_config:
   briefs:
     preview:
       default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
     staging:
       default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
     production:
       default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
     preview:


### PR DESCRIPTION
For [this trello card.](https://trello.com/c/QMDgW23t)

Previously the job was run with no frameworks listed. This had the
effect of indexing all DOS frameworks (the api returns all frameworks if
a specific framework is not specified).

This is fine if just indexing, but causes an issue if creating an index.
This is due to a new check which ensures the mapping specified for the
new index is correct for the frameworks being indexed into it. This
check fails and stops the indexing script if you don't supply the
frameworks.

This change defines a default value for DOS frameworks for indexing, in
the same way as we currently do for G-Cloud indexing. This means the job
can still be called without providing a value for frameworks and
behaviour will be maintained. It also means that the new check will
pass.