### PR TITLE
Add supplier CSV jobs to data tab

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -83,6 +83,9 @@ jenkins_list_views:
       - database-backup
       - export-data-preview
       - export-data-production
+      - export-supplier-csv-preview
+      - export-supplier-csv-staging
+      - export-supplier-csv-production
       - index-services-preview
       - index-services-production
       - index-services-staging

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -92,8 +92,6 @@ jenkins_list_views:
       - index-briefs-preview
       - index-briefs-staging
       - index-briefs-production
-      - snapshot-g7-stats-preview
-      - snapshot-g7-stats-production
       - update-preview-index-alias
       - update-staging-index-alias
       - update-production-index-alias
@@ -107,18 +105,12 @@ jenkins_list_views:
       - visual-regression-preview
   - name: "Emails"
     jobs:
-      - notify-buyers-to-award-closed-briefs-4-weeks-preview
       - notify-buyers-to-award-closed-briefs-4-weeks-production
-      - notify-buyers-to-award-closed-briefs-8-weeks-preview
       - notify-buyers-to-award-closed-briefs-8-weeks-production
-      - notify-buyers-when-requirements-close-preview
       - notify-buyers-when-requirements-close-production
-      - notify-suppliers-of-awarded-briefs-preview
       - notify-suppliers-of-awarded-briefs-production
       - notify-suppliers-of-dos-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
-      - notify-suppliers-of-brief-withdrawals-preview
-      - notify-suppliers-of-brief-withdrawals-staging
       - notify-suppliers-of-brief-withdrawals-production
       - upload-dos-opportunities-email-list-production
   - name: "Utils and toolkit"

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -87,11 +87,11 @@ jenkins_list_views:
       - export-supplier-csv-staging
       - export-supplier-csv-production
       - index-services-preview
-      - index-services-production
       - index-services-staging
+      - index-services-production
       - index-briefs-preview
-      - index-briefs-production
       - index-briefs-staging
+      - index-briefs-production
       - snapshot-g7-stats-preview
       - snapshot-g7-stats-production
       - update-preview-index-alias
@@ -100,8 +100,8 @@ jenkins_list_views:
   - name: "Functional, visual, and smoke tests"
     jobs:
       - apps-are-up-preview
-      - apps-are-up-production
       - apps-are-up-staging
+      - apps-are-up-production
       - functional-tests-preview
       - functional-tests-staging
       - visual-regression-preview
@@ -118,8 +118,8 @@ jenkins_list_views:
       - notify-suppliers-of-dos-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-preview
-      - notify-suppliers-of-brief-withdrawals-production
       - notify-suppliers-of-brief-withdrawals-staging
+      - notify-suppliers-of-brief-withdrawals-production
       - upload-dos-opportunities-email-list-production
   - name: "Utils and toolkit"
     jobs:


### PR DESCRIPTION
So we can find the new jobs easily.

I think this just needs the `make jenkins TAGS=config` to be run, but that will trigger a restart.