### PR TITLE
Remove incorrect part of description

### DIFF
--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -21,7 +21,7 @@
 {% endfor %}
       - string:
           name: RELEASE_NAME
-          description: "Release name (eg 'release-42') to deploy. If blank, the current release will be re-deployed. NOTE: router version cannot be derived - *must* be manually specified."
+          description: "Release name (eg 'release-42') to deploy. If blank, the current release will be re-deployed."
     pipeline:
       script: |
         def notify_slack(icon, status) {


### PR DESCRIPTION
> description: "Release name (eg 'release-42') to deploy. If blank, the current release will be re-deployed. NOTE: router version cannot be derived - *must* be manually specified."

https://github.com/alphagov/digitalmarketplace-jenkins/commit/fe94a6041cd0c0bd9d565d7a64dc2313d8580bab#diff-1c4f77591f810ec30f72b50679af1162R25

Was not updated with

https://github.com/alphagov/digitalmarketplace-jenkins/commit/185aad93fb25fc1ff644b762b022e60e5c0db7d0

> Update release-app-to-paas job to allow derivation of release name fo……r all apps, including router


https://trello.com/c/rMBlHr3X/578-description-for-release-application-paas-is-inaccurate