### PR TITLE
Update DOS email jobs to include DOS3

### DIFF
--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -1,9 +1,11 @@
 {% set environments = ['production'] %}
+{% set framework_slugs = ['digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'] %}
 ---
 {% for environment in environments %}
+{% for framework_slug in framework_slugs %}
 - job:
-    name: "notify-suppliers-of-dos-opportunities-{{ environment }}"
-    display-name: "Notify suppliers of DOS opportunities - {{ environment }}"
+    name: "notify-suppliers-of-dos{{ framework_slug[-1] }}-opportunities-{{ environment }}"
+    display-name: "Notify suppliers of DOS{{ framework_slug[-1] }} opportunities - {{ environment }}"
     project-type: freestyle
     description: "Create and send mailchimp campaign to suppliers for the latest Digital Outcomes and Specialists opportunities"
     parameters:
@@ -43,8 +45,8 @@
           - project: notify-slack
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
-              USERNAME=dos-opportunities
-              JOB=Notify suppliers of the latest DOS opportunities - {{ environment }}
+              USERNAME=dos{{ framework_slug[-1] }}-opportunities
+              JOB=Notify suppliers of the latest DOS{{ framework_slug[-1] }} opportunities - {{ environment }}
               ICON=:briefs:
               STAGE={{ environment }}
               STATUS=FAILED
@@ -64,5 +66,6 @@
             FLAGS="$FLAGS --number_of_days=$NUMBER_OF_DAYS"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }} $FLAGS
+{% endfor %}
 {% endfor %}

--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -1,6 +1,9 @@
+{% set framework_slugs = ['digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'] %}
+---
+{% for framework_slug in framework_slugs %}
 - job:
-    name: "upload-dos-opportunities-email-list-production"
-    display-name: "Upload DOS opportunities email list - production"
+    name: "upload-dos{{ framework_slug[-1] }}-opportunities-email-list-production"
+    display-name: "Upload DOS{{ framework_slug[-1] }} opportunities email list - production"
     project-type: freestyle
     description: "Subscribe new supplier emails to mailchimp lists which will be sent Digital Outcomes and Specialists opportunities emails"
     scm:
@@ -18,7 +21,7 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=mailchimp-lists
-              JOB=Upload DOS opportunities email list - production
+              JOB=Upload DOS{{ framework_slug[-1] }} opportunities email list - production
               ICON=:briefs:
               STAGE=production
               STATUS=FAILED
@@ -26,4 +29,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_PRODUCTION digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "jenkins" "$MAILCHIMP_API_TOKEN"
+          docker run -e DM_DATA_API_TOKEN_PRODUCTION digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }}
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -69,9 +69,11 @@ build_monitor_jobs:
   - index-services-preview
   - index-services-production
   - notify-buyers-when-requirements-close-production
-  - notify-suppliers-of-dos-opportunities-production
+  - notify-suppliers-of-dos2-opportunities-production
+  - notify-suppliers-of-do3-opportunities-production
   - notify-suppliers-of-new-questions-answers-production
-  - upload-dos-opportunities-email-list-production
+  - upload-dos2-opportunities-email-list-production
+  - upload-dos3-opportunities-email-list-production
   - visual-regression-preview
 
 jenkins_list_views:
@@ -109,10 +111,12 @@ jenkins_list_views:
       - notify-buyers-to-award-closed-briefs-8-weeks-production
       - notify-buyers-when-requirements-close-production
       - notify-suppliers-of-awarded-briefs-production
-      - notify-suppliers-of-dos-opportunities-production
+      - notify-suppliers-of-dos2-opportunities-production
+      - notify-suppliers-of-dos3-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-production
-      - upload-dos-opportunities-email-list-production
+      - upload-dos2-opportunities-email-list-production
+      - upload-dos3-opportunities-email-list-production
   - name: "Utils and toolkit"
     jobs:
       - build-scripts


### PR DESCRIPTION
Part of [this trello ticket.](https://trello.com/c/y3Rv3kGC)

See [this PR on the scripts repo](https://github.com/alphagov/digitalmarketplace-scripts/pull/284) which implements the changes being utilised here.

Once we've transitions to DOS3, the DOS2 jobs can be dropped. Having oth
running in parallel for a while will make the transition easier and less
open to mistakes.