### PR TITLE
Upload opportunity data to DOS3 location

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -28,7 +28,7 @@
           rm -rf ./data && mkdir data
 
           docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}'
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv opportunity-data.csv --public
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-3/communications/data/opportunity-data.csv opportunity-data.csv --public
 
           {% if environment == "production" %}
           /usr/local/bin/gdrive --config "/var/lib/jenkins/.gdrive" sync upload --delete-extraneous ./data "{{ jenkins_gdrive_csv_data_export_folder_id }}"


### PR DESCRIPTION
See [this related PR on the buyer FE](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/837).

DOS2 is now expired, so it's confusing to serve the file from DOS2.
There's a PR on the buyer frontend (#837) to update the frontend link.