### PR TITLE
Remove DOS2 opportunities email jobs

### DIFF
--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -1,5 +1,5 @@
 {% set environments = ['production'] %}
-{% set framework_slugs = ['digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'] %}
+{% set framework_slugs = ['digital-outcomes-and-specialists-3'] %}
 ---
 {% for environment in environments %}
 {% for framework_slug in framework_slugs %}

--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -1,4 +1,4 @@
-{% set framework_slugs = ['digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'] %}
+{% set framework_slugs = ['digital-outcomes-and-specialists-3'] %}
 ---
 {% for framework_slug in framework_slugs %}
 - job:

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -69,10 +69,8 @@ build_monitor_jobs:
   - index-services-preview
   - index-services-production
   - notify-buyers-when-requirements-close-production
-  - notify-suppliers-of-dos2-opportunities-production
   - notify-suppliers-of-dos3-opportunities-production
   - notify-suppliers-of-new-questions-answers-production
-  - upload-dos2-opportunities-email-list-production
   - upload-dos3-opportunities-email-list-production
   - visual-regression-preview
 
@@ -111,11 +109,9 @@ jenkins_list_views:
       - notify-buyers-to-award-closed-briefs-8-weeks-production
       - notify-buyers-when-requirements-close-production
       - notify-suppliers-of-awarded-briefs-production
-      - notify-suppliers-of-dos2-opportunities-production
       - notify-suppliers-of-dos3-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-production
-      - upload-dos2-opportunities-email-list-production
       - upload-dos3-opportunities-email-list-production
   - name: "Utils and toolkit"
     jobs:


### PR DESCRIPTION
These jobs are now redundant as there will be no new DOS2 opportunities
published on the Digital Marketplace.