### PR TITLE
Remove confusing 'finished' message on slack job

### DIFF
--- a/job_definitions/notify_slack.yml
+++ b/job_definitions/notify_slack.yml
@@ -96,7 +96,7 @@
               )
 
               message.update({
-                  "text": "{} finished".format(JOB),
+                  "text": JOB,
                   "attachments": [{
                       "fallback": "\n".join("{}: {}".format(key, val) for key, val, short in fields_def),
                       "color": color_from_status(STATUS),


### PR DESCRIPTION
Trello: https://trello.com/c/GTueLBfq/181-notify-slack-job-adds-finished-to-every-message

Possibly the quickest Quick Win that ever won?