### PR TITLE
Change email jobs to use Notify

### DIFF
--- a/job_definitions/notify_buyers_when_requirements_close.yml
+++ b/job_definitions/notify_buyers_when_requirements_close.yml
@@ -45,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --email-api-key="$MANDRILL_API_KEY_{{ environment|upper }}" $FLAGS
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --email-api-key="$NOTIFY_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -45,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $MANDRILL_API_KEY_{{ environment|upper }} $FLAGS
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $NOTIFY_API_TOKEN $FLAGS
 {% endfor %}


### PR DESCRIPTION
The email scripts notify-buyers-when-requirements-close and
notify-suppliers-of-new-questions-answers have been ported from Mandrill
to Notify.

This means that the Jenkins job definition needs to change to provide
the correct key to the script command line arguments.