### PR TITLE
virus-scan-s3-bucket job: upgrade to use api-calling script 

### DIFF
--- a/job_definitions/build_scripts.yml
+++ b/job_definitions/build_scripts.yml
@@ -5,7 +5,8 @@
     description: Build the scripts Docker image and upload it to Docker Hub
     concurrent: false
     triggers:
-      - pollscm: "* * * * *"
+      - pollscm:
+          cron: "* * * * *"
     pipeline:
       script: |
 

--- a/job_definitions/frameworks.yml
+++ b/job_definitions/frameworks.yml
@@ -15,7 +15,8 @@
             - master
           skip-tag: true
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     builders:

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -26,7 +26,8 @@
             - "master"
           wipe-workspace: false
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     publishers:

--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -11,7 +11,8 @@
           branches:
             - master
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     builders:
       - shell: |
           [ -x /tmp/dm-manual-venv/bin/pip ] || virtualenv /tmp/dm-manual-venv

--- a/job_definitions/publish_framework_application_guidance.yml
+++ b/job_definitions/publish_framework_application_guidance.yml
@@ -6,7 +6,8 @@
       Builds digitalmarketplace-framework-application-guidance and publishes it on Github Pages
     concurrent: false
     triggers:
-      - pollscm: "* * * * *"
+      - pollscm:
+          cron: "* * * * *"
     pipeline:
       script: |
         node {

--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -7,7 +7,8 @@
     description: Promote {{ application }} through environments
     concurrent: true
     triggers:
-      - pollscm: "* * * * *"
+      - pollscm:
+          cron: "* * * * *"
     pipeline:
       script: |
 

--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -17,7 +17,8 @@
             - master
           skip-tag: true
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     builders:

--- a/job_definitions/toolkit.yml
+++ b/job_definitions/toolkit.yml
@@ -15,7 +15,8 @@
             - master
           skip-tag: true
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     builders:
@@ -35,7 +36,8 @@
             - '*/tags/*'
           skip-tag: true
     triggers:
-      - pollscm: "H/2 * * * *"
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     builders:

--- a/job_definitions/virus_scan_s3_bucket.yml
+++ b/job_definitions/virus_scan_s3_bucket.yml
@@ -38,4 +38,31 @@
           fi
 
           docker run -e DM_ANTIVIRUS_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/virus-scan-s3-bucket.py {{ environment }} ${BUCKETS} --concurrency="${CONCURRENCY}" --prefix="${PREFIX}" ${FLAGS}
+- job:
+    name: "virus-scan-s3-buckets-nightly-{{ environment }}"
+    display-name: "Virus scan S3 buckets nightly - {{ environment }}"
+    project-type: freestyle
+    triggers:
+      - timed: "H 3 * * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=virus-scan
+              JOB=Virus scan S3 buckets nightly - {{ environment }}
+              ICON=:biohazard_sign:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-2ndline
+    builders:
+      - trigger-builds:
+          - project: "virus-scan-s3-buckets-{{ environment }}"
+            condition: UNSTABLE_OR_WORSE
+            block: true
+            predefined-parameters: |
+              BUCKETS=digitalmarketplace-agreements-{{ environment }}-{{ environment }},digitalmarketplace-communications-{{ environment }}-{{ environment }},digitalmarketplace-documents-{{ environment }}-{{ environment }},digitalmarketplace-submissions-{{ environment }}-{{ environment }}
+              SINCE=49 hours ago
+              DRY_RUN=false
 {% endfor %}

--- a/job_definitions/virus_scan_s3_bucket.yml
+++ b/job_definitions/virus_scan_s3_bucket.yml
@@ -7,17 +7,17 @@
     parameters:
       - string:
           name: BUCKETS
-          description: "The buckets to virus scan, comma separated (e.g. digitalmarketplace-dev-uploads,other-bucket)"
+          description: "The buckets to virus scan, comma separated (e.g. `digitalmarketplace-dev-uploads,other-bucket`)"
       - string:
           name: PREFIX
-          description: "An object prefix to use when filtering files to scan (e.g. g-cloud-9/documents)"
+          description: "An object prefix to use when filtering files to scan (e.g. `g-cloud-9/documents`)"
       - string:
           name: SINCE
-          description: "A timezone-aware ISO8601 datetime string; if provided, only scan objects uploaded after this point in time (e.g. 2018-01-01T12:00:00Z)."
+          description: "A date string, as understood by `date(1)` (i.e. relative dates are supported); if provided, only scan objects uploaded after this point in time (e.g. `2018-01-01T12:00:00Z`, `32 hours ago`)."
       - string:
           name: CONCURRENCY
           default: 0
-          description: "Number of concurrent requests to make to Antivirus API. 0 disables concurrency & threading entirely"
+          description: "Number of concurrent requests to make to Antivirus API. `0` disables concurrency & threading entirely"
       - bool:
           name: DRY_RUN
           default: true
@@ -25,7 +25,8 @@
     builders:
       - shell: |
           if [ -n "$SINCE" ]; then
-            FLAGS="--since=$SINCE"
+            ISO_SINCE=$(date -u -Iseconds -d "$SINCE")
+            FLAGS="--since=$ISO_SINCE"
           fi
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/virus_scan_s3_bucket.yml
+++ b/job_definitions/virus_scan_s3_bucket.yml
@@ -1,49 +1,27 @@
+{% for environment in ['preview', 'staging', 'production'] %}
 - job:
-    name: "virus-scan-s3-bucket"
-    display-name: "Virus scan an S3 bucket"
+    name: "virus-scan-s3-buckets-{{ environment }}"
+    display-name: "Virus scan S3 bucket(s) - {{ environment }}"
     project-type: freestyle
-    description: "Run the `virus-scan-s3-bucket` script to stream documents from S3 to a deployed (ClamAV) virus scanner."
+    description: "Run the `virus-scan-s3-bucket` script to scan & tag files in buckets via the antivirus-api"
     parameters:
       - string:
-          name: BUCKET
-          description: "The bucket to virus scan (e.g. digitalmarketplace-dev-uploads)"
+          name: BUCKETS
+          description: "The buckets to virus scan, comma separated (e.g. digitalmarketplace-dev-uploads,other-bucket)"
       - string:
           name: PREFIX
           description: "An object prefix to use when filtering files to scan (e.g. g-cloud-9/documents)"
       - string:
-          name: HOST
-          description: "The exposed host on which clamd is available (e.g. https://clamav.some.url"
-      - string:
-          name: PORT
-          default: "3310"
-          description: "The exposed port on which clamd is available (default: 3310)."
-      - string:
           name: SINCE
           description: "A timezone-aware ISO8601 datetime string; if provided, only scan objects uploaded after this point in time (e.g. 2018-01-01T12:00:00Z)."
+      - string:
+          name: CONCURRENCY
+          default: 0
+          description: "Number of concurrent requests to make to Antivirus API. 0 disables concurrency & threading entirely"
       - bool:
           name: DRY_RUN
           default: true
-          description: "A dry run will not bypass retrieving the object from S3 and send an empty file object to ClamAV."
-    publishers:
-      - trigger-parameterized-builds:
-          - project: notify-slack
-            condition: SUCCESS
-            predefined-parameters: |
-              USERNAME=Jenkins
-              JOB=Virus scan S3 bucket
-              ICON=:clean:
-              STATUS=SUCCESS
-              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
-          - project: notify-slack
-            condition: UNSTABLE_OR_WORSE
-            predefined-parameters: |
-              USERNAME=Jenkins
-              JOB=Virus scan S3 bucket
-              ICON=:can-of-worms:
-              STATUS=FAILED
-              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+          description: "A dry run will not send any requests to the antivirus-api, but will print a list of those it would have."
     builders:
       - shell: |
           if [ -n "$SINCE" ]; then
@@ -54,4 +32,9 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run digitalmarketplace/scripts scripts/virus-scan-s3-bucket.py ${BUCKET} --prefix="${PREFIX}" --host="${HOST}" --port="${PORT}" ${FLAGS}
+          if [ -z "$CONCURRENCY" ]; then
+            CONCURRENCY="0"
+          fi
+
+          docker run -e DM_ANTIVIRUS_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/virus-scan-s3-bucket.py {{ environment }} ${BUCKETS} --concurrency="${CONCURRENCY}" --prefix="${PREFIX}" ${FLAGS}
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -129,6 +129,9 @@ jenkins_list_views:
       - virus-scan-s3-buckets-preview
       - virus-scan-s3-buckets-staging
       - virus-scan-s3-buckets-production
+      - virus-scan-s3-buckets-nightly-preview
+      - virus-scan-s3-buckets-nightly-staging
+      - virus-scan-s3-buckets-nightly-production
   - name: "Release"
     jobs:
       - release-antivirus-api

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -126,7 +126,9 @@ jenkins_list_views:
       - update-credentials
       - rotate-api-tokens
       - rotate-production-notify-callback-token
-      - virus_scan_s3_bucket
+      - virus-scan-s3-buckets-preview
+      - virus-scan-s3-buckets-staging
+      - virus-scan-s3-buckets-production
   - name: "Release"
     jobs:
       - release-antivirus-api


### PR DESCRIPTION
https://trello.com/c/eI2PEVIY/202-create-jenkins-job-for-virus-scanning-catchup-script

Also includes an upgrade of the `pollscm` syntax usage to please new JJB.

Not included in this: periodic triggers, but I'm presenting this now because it's what's already been pushed to jenkins.