### PR TITLE
Separate playbook for upgrading packages

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -16,6 +16,30 @@ jenkins_java_args: ""
 jobs: '*'
 jobs_disabled: false
 
+dist_tools:
+  - git
+  - libpq-dev
+  - python-dev
+  - libyaml-dev
+  - libreadline-dev
+  - libffi-dev
+  - postgresql-client-9.5
+  - curl
+  - zip
+  - unzip
+  - ntp
+  - jq
+  - xvfb
+  - wkhtmltopdf
+  - fonts-liberation
+  - gnupg2
+  - make
+  - zlib1g-dev
+  - bzip2
+  - libsqlite3-dev
+  - libssl-dev
+  - python3-pip
+
 dm_applications:
   - api
   - search-api

--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -24,29 +24,7 @@
 - name: Install tools
   tags: [apt]
   apt: update_cache=yes name={{ item }} state=present
-  with_items:
-    - git
-    - libpq-dev
-    - python-dev
-    - libyaml-dev
-    - libreadline-dev
-    - libffi-dev
-    - postgresql-client-9.5
-    - curl
-    - zip
-    - unzip
-    - ntp
-    - jq
-    - xvfb
-    - wkhtmltopdf
-    - fonts-liberation
-    - gnupg2
-    - make
-    - zlib1g-dev
-    - bzip2
-    - libsqlite3-dev
-    - libssl-dev
-    - python3-pip
+  with_items: "{{ dist_tools }}"
 
 - name: Install AWS cli
   pip:

--- a/playbooks/roles/jenkins/tasks/upgrade_packages.yml
+++ b/playbooks/roles/jenkins/tasks/upgrade_packages.yml
@@ -1,0 +1,6 @@
+---
+# Upgrades packages separately from the main Jenkins build playbook
+- name: Upgrade all packages to the latest version
+  tags: [apt]
+  apt: update_cache=yes name={{ item }} state=latest
+  with_items: "{{ dist_tools }}"


### PR DESCRIPTION
Trello: https://trello.com/c/OujrG25u/486-update-git-version-on-jenkins

This playbook would be run with `make jenkins TAGS=upgrade_packages`.

For DRYness I've put the package list into the defaults file.

I haven't run it yet! Locally I have `check_mode: yes` enabled, I can try it out tomorrow unless anyone spots something weird.