### PR TITLE
nightly virus-scan-s3-buckets job: only notify slack for production

### DIFF
--- a/job_definitions/virus_scan_s3_bucket.yml
+++ b/job_definitions/virus_scan_s3_bucket.yml
@@ -44,6 +44,16 @@
     project-type: freestyle
     triggers:
       - timed: "H 3 * * *"
+    builders:
+      - trigger-builds:
+          - project: "virus-scan-s3-buckets-{{ environment }}"
+            condition: UNSTABLE_OR_WORSE
+            block: true
+            predefined-parameters: |
+              BUCKETS=digitalmarketplace-agreements-{{ environment }}-{{ environment }},digitalmarketplace-communications-{{ environment }}-{{ environment }},digitalmarketplace-documents-{{ environment }}-{{ environment }},digitalmarketplace-submissions-{{ environment }}-{{ environment }}
+              SINCE=49 hours ago
+              DRY_RUN=false
+{% if environment != 'preview' %}
     publishers:
       - trigger-parameterized-builds:
           - project: notify-slack
@@ -56,13 +66,5 @@
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-2ndline
-    builders:
-      - trigger-builds:
-          - project: "virus-scan-s3-buckets-{{ environment }}"
-            condition: UNSTABLE_OR_WORSE
-            block: true
-            predefined-parameters: |
-              BUCKETS=digitalmarketplace-agreements-{{ environment }}-{{ environment }},digitalmarketplace-communications-{{ environment }}-{{ environment }},digitalmarketplace-documents-{{ environment }}-{{ environment }},digitalmarketplace-submissions-{{ environment }}-{{ environment }}
-              SINCE=49 hours ago
-              DRY_RUN=false
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
We don't want to be woken by failures on preview.