### PR TITLE
Fix update index alias job

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -111,7 +111,7 @@
                   ]
                 }
                 stage('Update index alias'){
-                  build job: "update-{{ environment }}-index-alias",
+                  build job: "update-index-alias-{{ environment }}",
                   parameters: [
                     string(name: 'ALIAS', value: "{{ search_config['services'][environment].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
@@ -129,7 +129,7 @@
                   ]
                 }
                 stage('Update index alias'){
-                  build job: "update-{{ environment }}-index-alias",
+                  build job: "update-index-alias-{{ environment }}",
                   parameters: [
                     string(name: 'ALIAS', value: "{{ search_config['briefs'][environment].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),

--- a/job_definitions/create_index.yml
+++ b/job_definitions/create_index.yml
@@ -13,7 +13,7 @@
       You can use the above to get an idea of naming conventions.
 
       Once you have created your new index you might want to use it on the site. To do so, you can give your new index
-      an 'alias' here https://ci.marketplace.team/job/update-{{ environment }}-index-alias/
+      an 'alias' here https://ci.marketplace.team/job/update-index-alias-{{ environment }}/
     parameters:
       - choice:
           name: OBJECTS

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -31,18 +31,19 @@
     pipeline:
       script: |
         node {
-          withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials"]){
-            stage('Update alias'){
-              git url: 'git@github.com:alphagov/digitalmarketplace-scripts.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
-              sh('''
-                VIRTUALENV_ROOT=$([ -z ${VIRTUAL_ENV} ] && echo $(pwd)/venv || echo ${VIRTUAL_ENV})
-                [ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv venv || true
-                source ${VIRTUALENV_ROOT}/bin/activate
-                ${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
-
-                docker run -e "DM_SEARCH_API_TOKEN_{{ environment|upper }}" -e "DM_DATA_API_TOKEN_{{ environment|upper }}" digitalmarketplace/scripts scripts/update-index-alias.py "${ALIAS}" "${TARGET}" "{{ app_urls[environment].search_api }}" --stage="{{ environment }}" --delete-old-index=${DELETE_OLD_INDEX}
-              ''')
-            }
+          stage('Update alias'){
+            sh('''
+              docker run \
+                -e "DM_SEARCH_API_TOKEN_{{ environment|upper }}" \
+                -e "DM_DATA_API_TOKEN_{{ environment|upper }}" \
+                digitalmarketplace/scripts \
+                scripts/update-index-alias.py \
+                "${ALIAS}" \
+                "${TARGET}" \
+                "{{ app_urls[environment].search_api }}" \
+                --stage="{{ environment }}" \
+                --delete-old-index=${DELETE_OLD_INDEX}
+            ''')
           }
         }
 {% endfor %}

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -1,7 +1,7 @@
 {% for environment in ['preview', 'staging', 'production'] %}
 - job:
-    name: "update-{{ environment }}-index-alias"
-    display-name: "Update {{ environment }} index alias"
+    name: "update-index-alias-{{ environment }}"
+    display-name: "Update index alias - {{ environment }}"
     description: >
         Create an alias for a given elasticsearch index.
         If there is an index with that alias already then

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -114,9 +114,9 @@ jenkins_list_views:
       - index-briefs-preview
       - index-briefs-staging
       - index-briefs-production
-      - update-preview-index-alias
-      - update-staging-index-alias
-      - update-production-index-alias
+      - update-index-alias-preview
+      - update-index-alias-staging
+      - update-index-alias-production
   - name: "Functional, visual, and smoke tests"
     jobs:
       - apps-are-up-preview


### PR DESCRIPTION
Recently this job failed because the pip requirements file for digitalmarketplace-scripts was in a bad state. However, this should not have caused the job to fail, because this script was being run in a Docker container.

This PR removes the dead code that caused the failure.

It also renames the update index alias job naming to be consistent with other similar jobs.