### PR TITLE
Fix logrotate warnings

### DIFF
--- a/job_definitions/frameworks.yml
+++ b/job_definitions/frameworks.yml
@@ -4,9 +4,10 @@
     display-name: "Tag framework content"
     project-type: freestyle
     description: "Push the git tag on the https://github.com/alphagov/digitalmarketplace-frameworks repository."
-    logrotate:
-      daysToKeep: 20
-      artifactDaysToKeep: 20
+    properties:
+      build-discarder:
+        days-to-keep: 20
+        artifact-days-to-keep: 20
     scm:
       - git:
           url: git@github.com:alphagov/digitalmarketplace-frameworks.git

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -15,9 +15,10 @@
     display-name: "Functional tests - {{ job.display_name }}"
     project-type: freestyle
     description: "{{ job.description }}"
-    logrotate:
-      daysToKeep: 4
-      artifactDaysToKeep: 4
+    properties:
+      build-discarder:
+        days-to-keep: 4
+        artifact-days-to-keep: 4
     scm:
       - git:
           url: git@github.com:alphagov/digitalmarketplace-functional-tests.git

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -18,9 +18,10 @@
     concurrent: false
     triggers:
       - timed: 'H 1 * * *'
-    logrotate:
-      daysToKeep: 7
-      artifactDaysToKeep: 7
+    properties:
+      build-discarder:
+        days-to-keep: 7
+        artifact-days-to-keep: 7
     pipeline:
       script: |
         node {

--- a/job_definitions/notify_slack.yml
+++ b/job_definitions/notify_slack.yml
@@ -4,9 +4,10 @@
     display-name: "Notify slack"
     project-type: freestyle
     description:
-    logrotate:
-      daysToKeep: 4
-      artifactDaysToKeep: 4
+    properties:
+      build-discarder:
+        days-to-keep: 4
+        artifact-days-to-keep: 4
     parameters:
       - string:
           name: USERNAME

--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -17,9 +17,10 @@
         <li>Supplier frontend</li>
         <li>User frontend</li>
       </ul>
-    logrotate:
-      daysToKeep: 4
-      artifactDaysToKeep: 4
+    properties:
+      build-discarder:
+        days-to-keep: 4
+        artifact-days-to-keep: 4
     triggers:
       - timed: "H/5 * * * *"
     wrappers:

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -9,9 +9,10 @@
     display-name: "Snapshot {{ framework }} stats - {{ environment }}"
     project-type: freestyle
     description: Creates an hourly snapshot of framework stats and stores it in the API audit event
-    logrotate:
-      daysToKeep: 20
-      artifactDaysToKeep: 20
+    properties:
+      build-discarder:
+        days-to-keep: 20
+        artifact-days-to-keep: 20
     triggers:
       - timed: "H * * * *"
     publishers:

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -11,9 +11,10 @@
     display-name: "Send {{ framework }} stats to performance platform per {{ period }} - {{ environment }}"
     project-type: freestyle
     description: Sends a regular snapshot of framework stats to the performance platform
-    logrotate:
-      daysToKeep: 20
-      artifactDaysToKeep: 20
+    properties:
+      build-discarder:
+        days-to-keep: 20
+        artifact-days-to-keep: 20
     triggers:
       - timed: {{ schedule }}
     publishers:

--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -6,9 +6,10 @@
     display-name: "Tag dm{{ package }}"
     project-type: freestyle
     description: "Push the git tag on the https://github.com/alphagov/digitalmarketplace-{{ package }} repository."
-    logrotate:
-      daysToKeep: 20
-      artifactDaysToKeep: 20
+    properties:
+      build-discarder:
+        days-to-keep: 20
+        artifact-days-to-keep: 20
     scm:
       - git:
           url: git@github.com:alphagov/digitalmarketplace-{{ package }}.git

--- a/job_definitions/toolkit.yml
+++ b/job_definitions/toolkit.yml
@@ -4,9 +4,10 @@
     display-name: "Tag toolkit"
     project-type: freestyle
     description: "Push the git tag on the https://github.com/alphagov/digitalmarketplace-frontend-toolkit repository."
-    logrotate:
-      daysToKeep: 20
-      artifactDaysToKeep: 20
+    properties:
+      build-discarder:
+        days-to-keep: 20
+        artifact-days-to-keep: 20
     scm:
       - git:
           url: git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -5,11 +5,12 @@
     display-name: "Visual regression - {{ environment }}"
     project-type: freestyle
     description: "Run visual regression tests against {{ environment }}"
-    logrotate:
-      daysToKeep: 14
-      numToKeep: 50
-      artifactDaysToKeep: 14
-      artifactNumToKeep: 50
+    properties:
+      build-discarder:
+        days-to-keep: 14
+        num-to-keep: 50
+        artifact-days-to-keep: 14
+        artifact-num-to-keep: 50
     parameters:
       - choice:
           name: COMMAND


### PR DESCRIPTION
logrotate is deprecated on jenkins>=1.637, use the property build-discarder on newer jenkins instead