### PR TITLE
Add Jenkins Job Builder lint tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+install:
+  - sudo apt-get install jq
+  - make requirements-test
+script:
+  - make test ARGS=-v

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,19 @@ endif
 help: ## List available commands
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: requirements
-requirements: venv ## Install requirements
-	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
-
 .PHONY: venv
 venv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
 
 ${VIRTUALENV_ROOT}/activate:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+
+.PHONY: requirements
+requirements: venv ## Install requirements
+	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
+
+.PHONY: requirements-test
+requirements-test: requirements ## Install test requirements
+	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements-jenkins-job-builder.txt
 
 .PHONY: clean
 clean: ## Clean workspace (delete all generated files)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ requirements: venv ## Install requirements
 .PHONY: requirements-test
 requirements-test: requirements ## Install test requirements
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements-jenkins-job-builder.txt
+ifeq (, $(shell which jq))
+	$(error jjb-lint.sh requires jq, please ensure it is installed)
+endif
+
+.PHONY: test
+test: requirements-test
+	source ${VIRTUALENV_ROOT}/bin/activate && tools/jjb-lint/jjb-lint.sh job_definitions/*.yml
 
 .PHONY: clean
 clean: ## Clean workspace (delete all generated files)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 .PHONY: test
 test: requirements-test
-	source ${VIRTUALENV_ROOT}/bin/activate && tools/jjb-lint/jjb-lint.sh job_definitions/*.yml
+	source ${VIRTUALENV_ROOT}/bin/activate && tools/jjb-lint/jjb-lint.sh ${ARGS} job_definitions/*.yml
 
 .PHONY: clean
 clean: ## Clean workspace (delete all generated files)

--- a/playbooks/roles/jenkins/tasks/jobs.yml
+++ b/playbooks/roles/jenkins/tasks/jobs.yml
@@ -5,10 +5,7 @@
 
 - name: copy a requirements file with pinned Python dependencies
   copy:
-    content: |
-      python-jenkins==0.4.15  # newer ones have broken basic auth :(
-      jenkins-job-builder==1.6.2
-      git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline
+    src: ../../../../requirements-jenkins-job-builder.txt
     dest: /tmp/jenkins-jobs-python-requirements.txt
     force: yes
 

--- a/requirements-jenkins-job-builder.txt
+++ b/requirements-jenkins-job-builder.txt
@@ -1,0 +1,3 @@
+python-jenkins==0.4.15  # newer ones have broken basic auth :(
+jenkins-job-builder==1.6.2
+git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline

--- a/tests/jenkins-vars.yml
+++ b/tests/jenkins-vars.yml
@@ -1,0 +1,57 @@
+jenkins_api_user: jenkins-api-user
+jenkins_api_user_github_personal_access_token: --jenkins-api-user-github-personal-access-token--
+jenkins_github_email: jenkins+github@example.com
+jenkins_gdrive_db_dumps_folder_id: __jenkins_gdrive_db_dumps_folder_id__
+jenkins_gdrive_csv_data_export_folder_id: __jenkins_gdrive_csv_data_export_folder_id__
+jenkins_slack_url: slack.example.com/?user=jenkins
+performance_platform_bearer_tokens:
+  digital-outcomes-specialists: SuperSecretPerformancePlatformBearerTokenForDOS
+smoke_test_variables:
+  preview:
+    admin_email: admin+smoke_test+preview@example.com
+    admin_password: PreviewSmokeTestAdminPassword
+    admin_ccs_category_email: admin_ccs_category+smoke_test+preview@example.com
+    admin_ccs_category_password: PreviewSmokeTestAdminCCSCategoryPassword
+    admin_ccs_sourcing_email: admin_ccs_sourcing+smoke_test+preview@example.com
+    admin_ccs_sourcing_password: PreviewSmokeTestAdminCCSSourcingPassword
+    admin_manager_email: admin_manager+smoke_test+preview@example.com
+    admin_manager_password: PreviewSmokeTestAdminManagerPassword
+    admin_framework_manager_email: admin_framework_manager+smoke_test+preview@example.com
+    admin_framework_manager_password: PreviewSmokeTestAdminFrameworkManagerPassword
+    buyer_email: buyer+smoke_test+preview@example.com
+    buyer_password: PreviewSmokeTestBuyerPassword
+    supplier_email: supplier+smoke_test+preview@example.com
+    supplier_id: 11235
+    supplier_password: PreviewSmokeTestSupplierPassword
+  staging:
+    admin_email: admin+smoke_test+staging@example.com
+    admin_password: StagingSmokeTestAdminPassword
+    admin_ccs_category_email: admin_ccs_category+smoke_test+staging@example.com
+    admin_ccs_category_password: StagingSmokeTestAdminCCSCategoryPassword
+    admin_ccs_sourcing_email: admin_ccs_sourcing+smoke_test+staging@example.com
+    admin_ccs_sourcing_password: StagingSmokeTestAdminCCSSourcingPassword
+    admin_manager_email: admin_manager+smoke_test+staging@example.com
+    admin_manager_password: StagingSmokeTestAdminManagerPassword
+    admin_framework_manager_email: admin_framework_manager+smoke_test+staging@example.com
+    admin_framework_manager_password: StagingSmokeTestAdminFrameworkManagerPassword
+    buyer_email: buyer+smoke_test+staging@example.com
+    buyer_password: StagingSmokeTestBuyerPassword
+    supplier_email: supplier+smoke_test+staging@example.com
+    supplier_id: 11235
+    supplier_password: StagingSmokeTestSupplierPassword
+  production:
+    admin_email: admin+smoke_test+production@example.com
+    admin_password: ProductionSmokeTestAdminPassword
+    admin_ccs_category_email: admin_ccs_category+smoke_test+production@example.com
+    admin_ccs_category_password: ProductionSmokeTestAdminCCSCategoryPassword
+    admin_ccs_sourcing_email: admin_ccs_sourcing+smoke_test+production@example.com
+    admin_ccs_sourcing_password: ProductionSmokeTestAdminCCSSourcingPassword
+    admin_manager_email: admin_manager+smoke_test+production@example.com
+    admin_manager_password: ProductionSmokeTestAdminManagerPassword
+    admin_framework_manager_email: admin_framework_manager+smoke_test+production@example.com
+    admin_framework_manager_password: ProductionSmokeTestAdminFrameworkManagerPassword
+    buyer_email: buyer+smoke_test+production@example.com
+    buyer_password: ProductionSmokeTestBuyerPassword
+    supplier_email: supplier+smoke_test+production@example.com
+    supplier_id: 11235
+    supplier_password: ProductionSmokeTestSupplierPassword

--- a/tools/jjb-lint/jjb-lint.sh
+++ b/tools/jjb-lint/jjb-lint.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+
+usage() {
+	echo "Usage: jjb-lint [-h] [-dvx] FILE..."
+	echo "Check for basic errors in Jenkins Job Builder .yml files."
+	echo "Supports .yml files that are templated using ansible."
+	echo ""
+	echo "  -h	Display this help message and exit"
+	echo "  -d	Do not clean temporary files (useful for debugging)"
+	echo "  -v	Verbose mode, use multiple times for more detail"
+	echo "  -x	Exit on first issue found"
+	echo ""
+	echo "Exits with zero if no issues are found, non-zero otherwise."
+	echo "Exit status 127 indicates a fatal error occured."
+	echo ""
+	echo "For details on Jenkins Job Builder go to <https://docs.openstack.org/infra/jenkins-job-builder/>"
+}
+
+###############################################
+## Main functions
+## Define main at the top, called at the bottom
+###############################################
+
+main()
+{
+	# Run ansible_lint to generate files
+	# suitable for jenkins-jobs, then
+	# lint the generated files.
+
+	cd "$OUTDIR"
+	mkdir "job_definitions"
+	OUTDIR=job_definitions
+	catch ansible_lint "${FILES[@]}"
+	catch jjb_lint job_definitions/*.yml
+
+	trace -v "finished: $STATUS"
+
+	return "$STATUS"
+}
+
+run_ansible()
+{
+	# Usage: run_ansbile OUTDIR FILES...
+	local dest
+	local items
+	local status
+
+	dest="$(pwd)"/"$1"; shift
+	items="$1"; shift
+	while (($#))
+	do
+		items+=","
+		items+="$1"
+		shift
+	done
+
+	try \
+	ansible-playbook "$ANSIBLE_VERBOSE" \
+		--inventory="localhost," \
+		--extra-vars=@"${DM_JENKINS_REPO}/playbooks/roles/jenkins/defaults/main.yml" \
+		--extra-vars="dest=$dest" \
+		--extra-vars="items=[$items]" \
+		"${LIBDIR}/test_templates.yml"
+}
+
+run_jjb()
+{
+	# Usage: run_jjb OUTDIR FILES...
+	echo "$2"
+	try \
+	jenkins-jobs \
+		test \
+		-o "$1" \
+		"$2" \
+		2>&1
+}
+
+parse_ansible_output()
+{
+	# This command is a filter that transforms
+	# ansible's output into a more human readable form.
+	#
+	# It echoes to stdout one line per issue,
+	# in the format
+	#   filename: error message
+	#
+	# It returns 1 if any of the ansible jobs failed,
+	# 0 otherwise.
+
+	local status
+	status=0
+
+	while read -r line
+	do
+		# if there is a failure ansible emits a line that includes some json
+		# we use jq to parse the json and output the information we want in the correct format
+		echo "$line" | grep '^failed' | grep -o '{.*}' | jq -r '.item + ": " + .msg' | sed "s|$CWD/||"
+
+		# record if any of the output lines indicates a failure
+		if [[ "$line" == failed:* ]]
+		then
+			status=1
+			if [ "$FAILFAST" = "y" ]
+			then
+				exit 1
+			fi
+		fi
+	done
+
+	return $status
+}
+
+parse_jjb_output()
+{
+	# This command is a filter that transforms
+	# the output of jenkins-jobs messages.
+	#
+	# It echoes to stdout one line per issue,
+	# in the format
+	#   filename: error message
+	#
+	# It returns 1 if jenkins-jobs emitted any
+	# warnings or errors, 0 otherwise.
+
+	local status
+	status=0
+
+	# the first line from run_jjb will be the filename
+	local filename
+	read -r filename
+	filename=${filename##$CWD/}
+
+	while read -r line
+	do
+		# Print the warning line with reduced detail
+		# (remove the python logging prefixes)
+		echo "$filename: $line" | sed -n 's|WARNING:[^ ]*:||p'
+
+		# record if any of the output lines indicates a failure
+		if [[ "$line" == WARNING:* ]]
+		then
+			status=1
+			if [ "$FAILFAST" = "y" ]
+			then
+				exit 1
+			fi
+		fi
+	done
+
+	return $status
+}
+
+ansible_lint()
+{
+	# Usage: ansible_lint FILES...
+	# It saves any output files to $OUTDIR
+	# It logs to ansible.log
+	# Exit status is 1 if any files have issues
+
+	local status
+
+	run_ansible "$OUTDIR" "$@" | pipetrace -a "ansible.log" | parse_ansible_output
+	return $?
+}
+
+jjb_lint()
+{
+	# Usage: jjb_lint FILES...
+	# It saves any output files to $OUTDIR
+	# It logs to jenkins-jobs.log
+	# Exit status is 1 if any files have issues
+	local status
+	status=0
+
+	for f
+	do
+		# Use uniq before parsing the output because
+		# jenkins-jobs will emit an error for each
+		# job it finds in a YAML file; our yaml files
+		# often the same job repeated for different
+		# environments, so we filter out repeated lines
+		# to avoid noisy output
+
+		run_jjb "$OUTDIR" "$f" | pipetrace -a "jenkins-jobs.log" | uniq | parse_jjb_output
+
+		status=$((status|$?))
+		if [ "$FAILFAST" = "y" ] && [ $status -ne 0 ]
+		then
+			exit 1
+		fi
+	done
+	return $status
+}
+
+###################
+## Helper functions
+###################
+
+pipetrace()
+{
+	# A version of tee that prints
+	# to screen if $VERBOSE is set
+	if [[ "$VERBOSE" == -v* ]]
+	then
+		tee "$@" /dev/tty
+	else
+		tee "$@"
+	fi
+}
+
+trace()
+{
+	# echo to screen if verbose
+	local level
+	level=
+
+	if [ $# -gt 1 ]
+	then
+		level="$1"; shift
+	fi
+
+	if [[ "$VERBOSE" == "$level"* ]]
+	then
+		(>/dev/tty echo "$*")
+	fi
+}
+
+try()
+{
+	# issue an error message if command returns non-zero status
+	# and exit immediately with FATAL status code
+	local status
+	status=0
+
+	trace -vv "$*"
+
+	# call the command, must be unqoted
+	# shellcheck disable=SC2068
+	$@
+	status=$?
+	trace -vv "$1 exited with status code $status"
+	if [ $status -ne 0 ]
+	then
+		if [ -z "$VERBOSE" ]
+		then
+			# echo a helpful message to stderr
+			trace "$1 exited with status code $status, this may be due to an error, use -v to show more detail"
+		fi
+		exit "$FATAL"
+	fi
+
+	return 0
+}
+
+catch()
+{
+	# update STATUS
+	local status
+	status=0
+
+	"$@"
+	status=$?
+	trace -vv "$1 exited with status code $status"
+	STATUS=$((STATUS|status))
+	return 0
+}
+
+#######################################################
+## Env
+## Setup global vars and the environment for the script
+#######################################################
+
+set -Eeuo pipefail
+
+# Treat exit status 127 as fatal
+FATAL=127
+trap '[ "$?" -ne 127 ] || exit 127' ERR
+
+CWD="$( pwd )"
+DM_JENKINS_REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null && pwd )"
+LIBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/lib" >/dev/null && pwd )"
+OUTDIR=$(mktemp -d /tmp/jjb-lint.XXX)
+
+CLEAN=y
+FAILFAST=n
+STATUS=0
+VERBOSE=
+
+ANSIBLE_VERBOSE=  # setting this is useful if you have errors with ansible
+
+#############################
+## Parse command line options
+#############################
+
+while getopts "dhvx" opt
+do
+	case $opt in
+		d)
+			CLEAN=n
+			;;
+		v)
+			if [ -z "$VERBOSE" ]
+			then
+				VERBOSE+=-
+			fi
+			VERBOSE+=v
+			;;
+		x)
+			FAILFAST=y
+			;;
+		h|\?)
+			usage
+			exit 2
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+
+if [ "$CLEAN" = "y" ]
+then
+	# clean up afterwards
+	# we use double quotes because
+	# OUTDIR changes later
+	# shellcheck disable=SC2064
+	trap "rm -r $OUTDIR" EXIT
+else
+	echo "Temporary files will be saved to $OUTDIR..."
+fi
+
+# super verbose
+if [[ "$VERBOSE" = -vvvv* ]]
+then
+	set -x
+fi
+
+# get absolute file paths for FILE...
+# and save into array FILES
+declare -a FILES
+for f
+do
+	FILES+=("$CWD"/"$f")
+done
+
+# exit script if user hits Ctrl-C
+trap exit SIGINT
+
+# unfortunately having set -e catching errors
+# interferes with the logic of this script
+set +e
+
+#############
+## Entrypoint
+#############
+
+main

--- a/tools/jjb-lint/jjb-lint.sh
+++ b/tools/jjb-lint/jjb-lint.sh
@@ -58,6 +58,7 @@ run_ansible()
 	ansible-playbook "$ANSIBLE_VERBOSE" \
 		--inventory="localhost," \
 		--extra-vars=@"${DM_JENKINS_REPO}/playbooks/roles/jenkins/defaults/main.yml" \
+		--extra-vars=@"${DM_JENKINS_REPO}/tests/jenkins-vars.yml" \
 		--extra-vars="dest=$dest" \
 		--extra-vars="items=[$items]" \
 		"${LIBDIR}/test_templates.yml"

--- a/tools/jjb-lint/lib/test_templates.yml
+++ b/tools/jjb-lint/lib/test_templates.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: Process templates
+    template: src={{ item }} dest={{ dest }}
+    loop: "{{ items | from_yaml }}"


### PR DESCRIPTION
This is a second attempt at [adding local tests for our Jenkins Job Builder templates](https://github.com/alphagov/digitalmarketplace-jenkins/pull/160), which I think we need so that we can easily [update Jenkins Job Builder](https://trello.com/c/pSEUci7F/).

It is a bit simpler than #160 in the sense that it uses a bash script instead of a Makefile, but it is still pretty complicated. I looked into creating a Python tool but it would have involved having to use a bunch of private APIs for both ansible and JJB.

Comments and opinions are always welcome.