### PR TITLE
Quiet jenkins-jobs test deprecation warnings

### DIFF
--- a/playbooks/roles/jenkins/templates/jenkins_jobs.ini.j2
+++ b/playbooks/roles/jenkins/templates/jenkins_jobs.ini.j2
@@ -1,3 +1,6 @@
+[__future__]
+param_order_from_yaml=True
+
 [job_builder]
 ignore_cache=True
 keep_descriptions=False


### PR DESCRIPTION
Set the config option '__future__.param_order_from_yaml' to 'true' to
suppress warning messages from `jenkins-jobs test`.

I ran this against all our job definitions and it didn't change the
output according to diff, but having the config option set means the
warnings go away and the linter (#162) is happy.