### PR TITLE
Update Jenkins Job Builder to 2.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,19 @@ endif
 help: ## List available commands
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: requirements
-requirements: venv ## Install requirements
-	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
-
 .PHONY: venv
 venv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
 
 ${VIRTUALENV_ROOT}/activate:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+
+.PHONY: requirements
+requirements: venv ## Install requirements
+	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
+
+.PHONY: requirements-test
+requirements-test: requirements ## Install test requirements
+	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements-jenkins-job-builder.txt
 
 .PHONY: clean
 clean: ## Clean workspace (delete all generated files)

--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -19,54 +19,53 @@
           name: REBUILD
           default: false
           description: "Rerun the build even if the release already exists"
-    pipeline:
-      script: |
-        node {
-            try {
-                stage('Check previous builds') {
-                  currentBuild.displayName = "#${BUILD_NUMBER} - ${REPOSITORY} - ${RELEASE_NAME}"
-                  existingRelease = sh(script: "curl -fs https://index.docker.io/v1/repositories/digitalmarketplace/${REPOSITORY}/tags/${RELEASE_NAME}", returnStatus: true)
-                }
+    dsl: |
+      node {
+          try {
+              stage('Check previous builds') {
+                currentBuild.displayName = "#${BUILD_NUMBER} - ${REPOSITORY} - ${RELEASE_NAME}"
+                existingRelease = sh(script: "curl -fs https://index.docker.io/v1/repositories/digitalmarketplace/${REPOSITORY}/tags/${RELEASE_NAME}", returnStatus: true)
+              }
 
-                if (existingRelease == 0 && (REBUILD.toString() == "false")) {
-                  echo "Release ${RELEASE_NAME} already exists"
-                  currentBuild.result = 'SUCCESS'
-                  return
-                }
+              if (existingRelease == 0 && (REBUILD.toString() == "false")) {
+                echo "Release ${RELEASE_NAME} already exists"
+                currentBuild.result = 'SUCCESS'
+                return
+              }
 
-                stage('Prepare') {
-                    git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
-                    echo "Cleaning repository"
-                    sh("git clean -fdx")
-                    echo "Checking out ${RELEASE_NAME}"
-                    sh("git reset --hard ${RELEASE_NAME}")
-                }
-                stage('Build') {
-                    sh("docker build --pull -t digitalmarketplace/${REPOSITORY} --build-arg release_name=${RELEASE_NAME} .")
-                    sh("docker tag digitalmarketplace/${REPOSITORY} digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
-                }
-                stage('Upload') {
-                    docker_credentials = sh(script: '/var/lib/jenkins/digitalmarketplace-credentials/sops-wrapper -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
-                    withEnv(docker_credentials.tokenize("\n")) {
-                        sh("docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
-                    }
+              stage('Prepare') {
+                  git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+                  echo "Cleaning repository"
+                  sh("git clean -fdx")
+                  echo "Checking out ${RELEASE_NAME}"
+                  sh("git reset --hard ${RELEASE_NAME}")
+              }
+              stage('Build') {
+                  sh("docker build --pull -t digitalmarketplace/${REPOSITORY} --build-arg release_name=${RELEASE_NAME} .")
+                  sh("docker tag digitalmarketplace/${REPOSITORY} digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
+              }
+              stage('Upload') {
+                  docker_credentials = sh(script: '/var/lib/jenkins/digitalmarketplace-credentials/sops-wrapper -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
+                  withEnv(docker_credentials.tokenize("\n")) {
+                      sh("docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
+                  }
 
-                    sh("docker push digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
-                    sh("docker push digitalmarketplace/${REPOSITORY}:latest")
-                }
-            } catch(err) {
-                currentBuild.result = 'FAILURE'
-                echo "Error: ${err}"
-                build job: "notify-slack",
-                      parameters: [
-                        string(name: 'USERNAME', value: 'build-image'),
-                        string(name: 'ICON', value: ':rotating_light:'),
-                        string(name: 'JOB', value: "Build Docker image: ${REPOSITORY} - ${RELEASE_NAME}"),
-                        string(name: 'CHANNEL', value: "#dm-release"),
-                        string(name: 'PROJECT', value: "${REPOSITORY}"),
-                        text(name: 'RELEASE_NAME', value: "${RELEASE_NAME}"),
-                        text(name: 'STATUS', value: 'FAILED'),
-                        text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-                      ]
-            }
-        }
+                  sh("docker push digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
+                  sh("docker push digitalmarketplace/${REPOSITORY}:latest")
+              }
+          } catch(err) {
+              currentBuild.result = 'FAILURE'
+              echo "Error: ${err}"
+              build job: "notify-slack",
+                    parameters: [
+                      string(name: 'USERNAME', value: 'build-image'),
+                      string(name: 'ICON', value: ':rotating_light:'),
+                      string(name: 'JOB', value: "Build Docker image: ${REPOSITORY} - ${RELEASE_NAME}"),
+                      string(name: 'CHANNEL', value: "#dm-release"),
+                      string(name: 'PROJECT', value: "${REPOSITORY}"),
+                      text(name: 'RELEASE_NAME', value: "${RELEASE_NAME}"),
+                      text(name: 'STATUS', value: 'FAILED'),
+                      text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+                    ]
+          }
+      }

--- a/job_definitions/build_scripts.yml
+++ b/job_definitions/build_scripts.yml
@@ -7,47 +7,46 @@
     triggers:
       - pollscm:
           cron: "* * * * *"
-    pipeline:
-      script: |
+    dsl: |
 
-        def tag_release(tag) {
-          try {
-            sh("git config user.name 'Jenkins'")
-            sh("git config user.email '{{ jenkins_github_email }}'")
-            sh("git tag -a ${tag} -m ${tag}")
-            sh("git push origin ${tag} -f")
-          } catch(e) {
-            echo "${tag} tag already exists"
-          }
+      def tag_release(tag) {
+        try {
+          sh("git config user.name 'Jenkins'")
+          sh("git config user.email '{{ jenkins_github_email }}'")
+          sh("git tag -a ${tag} -m ${tag}")
+          sh("git push origin ${tag} -f")
+        } catch(e) {
+          echo "${tag} tag already exists"
         }
+      }
 
-        stage('Create release tag') {
-          node {
-            git url: "git@github.com:alphagov/digitalmarketplace-scripts.git",
-                branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
-            releaseNumber = sh(
-                script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
-                returnStdout: true
-            ).trim()
+      stage('Create release tag') {
+        node {
+          git url: "git@github.com:alphagov/digitalmarketplace-scripts.git",
+              branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+          releaseNumber = sh(
+              script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
+              returnStdout: true
+          ).trim()
 
-            if (releaseNumber == "") {
-                throw new Exception('Release number can not be found')
-            }
-
-            releaseName = "release-${releaseNumber}"
-
-            tag_release(releaseName)
-
-            echo "Release number: ${releaseNumber}"
-            currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
+          if (releaseNumber == "") {
+              throw new Exception('Release number can not be found')
           }
-        }
 
-        stage('Build') {
-          node {
-            build job: "build-image", parameters: [
-              string(name: "REPOSITORY", value: "scripts"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
+          releaseName = "release-${releaseNumber}"
+
+          tag_release(releaseName)
+
+          echo "Release number: ${releaseNumber}"
+          currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
         }
+      }
+
+      stage('Build') {
+        node {
+          build job: "build-image", parameters: [
+            string(name: "REPOSITORY", value: "scripts"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -11,34 +11,33 @@
     triggers:
       - timed: "0 4 * * 0"
 {% endif %}
-    pipeline:
-      script: |
+    dsl: |
 
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-          parameters: [
-            string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
-            string(name: 'ICON', value: icon),
-            string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
-            text(name: 'STAGE', value: "{{ environment }}"),
-            text(name: 'STATUS', value: status),
-            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-          ]
-        }
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
+          string(name: 'ICON', value: icon),
+          string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
+          string(name: 'CHANNEL', value: "#dm-release"),
+          text(name: 'STAGE', value: "{{ environment }}"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
 
-        node {
-          currentBuild.displayName = "#${BUILD_NUMBER} - {{ environment }}"
+      node {
+        currentBuild.displayName = "#${BUILD_NUMBER} - {{ environment }}"
 
-          withEnv([
-            "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
-            "CF_HOME=${pwd()}",
-            "PAAS_SPACE={{ environment }}"
-          ]) {
-            try {
-              stage('Prepare') {
-                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
-                build job: "update-credentials"
+        withEnv([
+          "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
+          "CF_HOME=${pwd()}",
+          "PAAS_SPACE={{ environment }}"
+        ]) {
+          try {
+            stage('Prepare') {
+              git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+              build job: "update-credentials"
 
 {% if environment in ['preview', 'staging'] %}
                 paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -12,80 +12,79 @@
           type: radio
           default-value: production
           value: preview,staging,production
-    pipeline:
-      script: |
+    dsl: |
 
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-                parameters: [
-                  string(name: 'USERNAME', value: "database-backup"),
-                  string(name: 'ICON', value: icon),
-                  string(name: 'JOB', value: "Backup ${STAGE} database to S3"),
-                  string(name: 'CHANNEL', value: "#dm-release"),
-                  text(name: 'STAGE', value: "${STAGE}"),
-                  text(name: 'STATUS', value: status),
-                  text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-                ]
-        }
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+              parameters: [
+                string(name: 'USERNAME', value: "database-backup"),
+                string(name: 'ICON', value: icon),
+                string(name: 'JOB', value: "Backup ${STAGE} database to S3"),
+                string(name: 'CHANNEL', value: "#dm-release"),
+                text(name: 'STAGE', value: "${STAGE}"),
+                text(name: 'STATUS', value: status),
+                text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+              ]
+      }
 
-        node {
-          currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
+      node {
+        currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
 
-          withEnv([
-            "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
-            "CF_HOME=${pwd()}",
-            "DUMP_FILE_NAME=${STAGE}-${new java.text.SimpleDateFormat('yyyyMMddHHmm').format(new Date())}.sql.gz.gpg"
-          ]) {
+        withEnv([
+          "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
+          "CF_HOME=${pwd()}",
+          "DUMP_FILE_NAME=${STAGE}-${new java.text.SimpleDateFormat('yyyyMMddHHmm').format(new Date())}.sql.gz.gpg"
+        ]) {
 
-            try {
+          try {
 
-              stage('Prepare') {
-                echo "Getting ready to create ${DUMP_FILE_NAME}"
-                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
-                build job: "update-credentials"
-                paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
-                withEnv(paas_credentials.tokenize("\n")) {
-                  sh('make paas-login')
-                }
+            stage('Prepare') {
+              echo "Getting ready to create ${DUMP_FILE_NAME}"
+              git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+              build job: "update-credentials"
+              paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+              withEnv(paas_credentials.tokenize("\n")) {
+                sh('make paas-login')
               }
+            }
 
-              stage('Connect to service, create dump and upload to S3') {
-                sh('''
-                  pyenv local 3.6.2
-                  make requirements
-                  DUMP_FILE_NAME=${DUMP_FILE_NAME} make ${STAGE} deploy-db-backup-app
-                ''')
-                timeout(10) {
-                  waitUntil {
-                    sleep 5
-                    def taskStatus = sh(
-                        script: 'make check-db-backup-task',
-                        returnStdout: true
-                    ).trim()
-                    echo "Task status is ${taskStatus}"
-                    if (taskStatus == 'FAILED') {
-                        sh("cf logs --recent db-backup")
-                        throw new Exception('Create db dump task failed')
-                    }
-                    return (taskStatus == 'SUCCEEDED');
+            stage('Connect to service, create dump and upload to S3') {
+              sh('''
+                pyenv local 3.6.2
+                make requirements
+                DUMP_FILE_NAME=${DUMP_FILE_NAME} make ${STAGE} deploy-db-backup-app
+              ''')
+              timeout(10) {
+                waitUntil {
+                  sleep 5
+                  def taskStatus = sh(
+                      script: 'make check-db-backup-task',
+                      returnStdout: true
+                  ).trim()
+                  echo "Task status is ${taskStatus}"
+                  if (taskStatus == 'FAILED') {
+                      sh("cf logs --recent db-backup")
+                      throw new Exception('Create db dump task failed')
                   }
+                  return (taskStatus == 'SUCCEEDED');
                 }
               }
+            }
 
-              stage('Check decryption') {
-                sh('DUMP_FILE_NAME=${DUMP_FILE_NAME} ./scripts/check-db-dump-is-decryptable.sh')
-              }
+            stage('Check decryption') {
+              sh('DUMP_FILE_NAME=${DUMP_FILE_NAME} ./scripts/check-db-dump-is-decryptable.sh')
+            }
 
-            } catch(err) {
-                notify_slack(':-1:', 'FAILED')
-                echo "Error caught"
-                currentBuild.result = 'FAILURE'
-                echo "Error: ${err}"
-            } finally {
-              stage('Cleanup') {
-                sh('make cleanup-db-backup')
-                sh('make paas-clean')
-              }
+          } catch(err) {
+              notify_slack(':-1:', 'FAILED')
+              echo "Error caught"
+              currentBuild.result = 'FAILURE'
+              echo "Error: ${err}"
+          } finally {
+            stage('Cleanup') {
+              sh('make cleanup-db-backup')
+              sh('make paas-clean')
             }
           }
         }
+      }

--- a/job_definitions/database_migration_paas.yml
+++ b/job_definitions/database_migration_paas.yml
@@ -19,68 +19,67 @@
       - string:
           name: RELEASE_NAME
           description: "Release name (eg 'release-42') to run migrations from"
-    pipeline:
-      script: |
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-                parameters: [
-                  string(name: 'USERNAME', value: "database-migration-paas"),
-                  string(name: 'ICON', value: icon),
-                  string(name: 'JOB', value: "Run database migrations for ${APPLICATION_NAME} on ${STAGE}"),
-                  string(name: 'CHANNEL', value: "#dm-release"),
-                  string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
-                  text(name: 'STAGE', value: "${STAGE}"),
-                  text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),
-                  text(name: 'STATUS', value: status),
-                  text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-                ]
-        }
+    dsl: |
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+              parameters: [
+                string(name: 'USERNAME', value: "database-migration-paas"),
+                string(name: 'ICON', value: icon),
+                string(name: 'JOB', value: "Run database migrations for ${APPLICATION_NAME} on ${STAGE}"),
+                string(name: 'CHANNEL', value: "#dm-release"),
+                string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
+                text(name: 'STAGE', value: "${STAGE}"),
+                text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),
+                text(name: 'STATUS', value: status),
+                text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+              ]
+      }
 
-        node {
+      node {
 
-            try {
-                git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+          try {
+              git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
 
-                stage('Prepare') {
-                    build job: "update-credentials"
-                    currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
-                    sh('make paas-clean')
-                    sh('pyenv local 3.6.2 && make requirements')
-                }
+              stage('Prepare') {
+                  build job: "update-credentials"
+                  currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
+                  sh('make paas-clean')
+                  sh('pyenv local 3.6.2 && make requirements')
+              }
 
-                stage('Run database migration') {
-                  withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
-                    paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
-                    withEnv(paas_credentials.tokenize("\n")) {
-                        sh('make paas-login')
-                    }
-                    lock("paas-${STAGE}-${APPLICATION_NAME}-deploy") {
-                        sh "make deploy-db-migration"
-                        timeout(2) {
-                            waitUntil {
-                                sleep 5
-                                def taskStatus = sh(
-                                    script: 'make check-db-migration-task',
-                                    returnStdout: true
-                                ).trim()
-                                echo "Task status is ${taskStatus}"
-                                if (taskStatus == 'FAILED') {
-                                    sh("cf logs --recent ${APPLICATION_NAME}-db-migration")
-                                    throw new Exception('Database migration task failed')
-                                } else if (taskStatus == 'SUCCEEDED') {
-                                    notify_slack(':duck:', 'SUCCESS')
-                                }
-                                return (taskStatus == 'SUCCEEDED');
-                            }
-                        }
-                    }
+              stage('Run database migration') {
+                withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
+                  paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+                  withEnv(paas_credentials.tokenize("\n")) {
+                      sh('make paas-login')
+                  }
+                  lock("paas-${STAGE}-${APPLICATION_NAME}-deploy") {
+                      sh "make deploy-db-migration"
+                      timeout(2) {
+                          waitUntil {
+                              sleep 5
+                              def taskStatus = sh(
+                                  script: 'make check-db-migration-task',
+                                  returnStdout: true
+                              ).trim()
+                              echo "Task status is ${taskStatus}"
+                              if (taskStatus == 'FAILED') {
+                                  sh("cf logs --recent ${APPLICATION_NAME}-db-migration")
+                                  throw new Exception('Database migration task failed')
+                              } else if (taskStatus == 'SUCCEEDED') {
+                                  notify_slack(':duck:', 'SUCCESS')
+                              }
+                              return (taskStatus == 'SUCCEEDED');
+                          }
+                      }
                   }
                 }
-            } catch(err) {
-                currentBuild.result = 'FAILURE'
-                echo "Error: ${err}"
-                notify_slack(':kaboom:', 'FAILED')
-            } finally {
-                sh('make paas-clean')
-            }
-        }
+              }
+          } catch(err) {
+              currentBuild.result = 'FAILURE'
+              echo "Error: ${err}"
+              notify_slack(':kaboom:', 'FAILED')
+          } finally {
+              sh('make paas-clean')
+          }
+      }

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -22,78 +22,77 @@
       build-discarder:
         days-to-keep: 7
         artifact-days-to-keep: 7
-    pipeline:
-      script: |
-        node {
-            try {
-              stage('Prepare') {
-                dir('scripts/generated-countersignature-pdfs') {
-                  deleteDir()
-                }
-                dir('scripts') {
-                  git url: "git@github.com:alphagov/digitalmarketplace-scripts.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
-                  echo "Cleaning scripts repository"
-                  sh('pwd')
-                  sh("git clean -fdx")
-                  sh("git reset --hard origin/master")
-                }
-                dir('agreements') {
-                  git url: "git@github.com:alphagov/digitalmarketplace-agreements.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
-                  echo "Cleaning agreements repository"
-                  sh('pwd')
-                  sh("git clean -fdx")
-                  sh("git reset --hard origin/master")
-                }
+    dsl: |
+      node {
+          try {
+            stage('Prepare') {
+              dir('scripts/generated-countersignature-pdfs') {
+                deleteDir()
               }
-              stage('Generate') {
-                dir('scripts') {
-                  sh('pyenv local 3.6.2')
-                  sh('[ -d venv ] || virtualenv venv')
-                  sh('source ./venv/bin/activate')
-                  sh('pip install --upgrade pip')
-                  sh('pip install -r requirements.txt')
-                  sh('xvfb-run --server-args="-screen 0, 1024x768x24" \
-                        python ./scripts/generate-framework-agreement-counterpart-signature-pages.py \
-                               {{ environment }} \
-                               {{ framework }} \
-                               ../agreements \
-                               generated-countersignature-pdfs')
-                }
+              dir('scripts') {
+                git url: "git@github.com:alphagov/digitalmarketplace-scripts.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+                echo "Cleaning scripts repository"
+                sh('pwd')
+                sh("git clean -fdx")
+                sh("git reset --hard origin/master")
               }
-              stage('Upload') {
-                dir('scripts') {
-                  sh('pyenv local 3.6.2')
-                  sh('[ -d venv ] || virtualenv venv')
-                  sh('source ./venv/bin/activate')
-                  sh('pip install --upgrade pip')
-                  sh('pip install -r requirements.txt')
-                  sh('python ./scripts/upload-counterpart-agreements.py \
-                  {{ environment }} \
-                  generated-countersignature-pdfs \
-                  {{ framework }} \
-                  --notify-key="$NOTIFY_API_TOKEN" \
-                  --notify-template-id=cdd836a0-02e2-4c8d-98a6-2544d63f5ea9 \
-                  ')
-                }
+              dir('agreements') {
+                git url: "git@github.com:alphagov/digitalmarketplace-agreements.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+                echo "Cleaning agreements repository"
+                sh('pwd')
+                sh("git clean -fdx")
+                sh("git reset --hard origin/master")
               }
-              stage('Cleanup') {
-                dir('scripts/generated-countersignature-pdfs') {
-                  deleteDir()
-                }
-              }
-            } catch(err) {
-              currentBuild.result = 'FAILURE'
-              echo "Error: ${err}"
-              build job: 'notify-slack', parameters: [
-                string(name: 'USERNAME', value: 'jenkins'),
-                string(name: 'JOB', value: 'Generate {{ framework }} counterpart signature pages'),
-                string(name: 'ICON', value: ':alarm_clock:'),
-                string(name: 'STAGE', value: '{{ environment }}'),
-                string(name: 'STATUS', value: 'FAILED'),
-                string(name: 'CHANNEL', value: '#dm-release')
-              ]
             }
-        }
+            stage('Generate') {
+              dir('scripts') {
+                sh('pyenv local 3.6.2')
+                sh('[ -d venv ] || virtualenv venv')
+                sh('source ./venv/bin/activate')
+                sh('pip install --upgrade pip')
+                sh('pip install -r requirements.txt')
+                sh('xvfb-run --server-args="-screen 0, 1024x768x24" \
+                      python ./scripts/generate-framework-agreement-counterpart-signature-pages.py \
+                             {{ environment }} \
+                             {{ framework }} \
+                             ../agreements \
+                             generated-countersignature-pdfs')
+              }
+            }
+            stage('Upload') {
+              dir('scripts') {
+                sh('pyenv local 3.6.2')
+                sh('[ -d venv ] || virtualenv venv')
+                sh('source ./venv/bin/activate')
+                sh('pip install --upgrade pip')
+                sh('pip install -r requirements.txt')
+                sh('python ./scripts/upload-counterpart-agreements.py \
+                {{ environment }} \
+                generated-countersignature-pdfs \
+                {{ framework }} \
+                --notify-key="$NOTIFY_API_TOKEN" \
+                --notify-template-id=cdd836a0-02e2-4c8d-98a6-2544d63f5ea9 \
+                ')
+              }
+            }
+            stage('Cleanup') {
+              dir('scripts/generated-countersignature-pdfs') {
+                deleteDir()
+              }
+            }
+          } catch(err) {
+            currentBuild.result = 'FAILURE'
+            echo "Error: ${err}"
+            build job: 'notify-slack', parameters: [
+              string(name: 'USERNAME', value: 'jenkins'),
+              string(name: 'JOB', value: 'Generate {{ framework }} counterpart signature pages'),
+              string(name: 'ICON', value: ':alarm_clock:'),
+              string(name: 'STAGE', value: '{{ environment }}'),
+              string(name: 'STATUS', value: 'FAILED'),
+              string(name: 'CHANNEL', value: '#dm-release')
+            ]
+          }
+      }
 
 {% endfor %}
 {% endfor %}

--- a/job_definitions/maintenance_mode.yml
+++ b/job_definitions/maintenance_mode.yml
@@ -19,58 +19,57 @@
             - maintenance
             - live
 
-    pipeline:
-      script: |
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-          parameters: [
-            string(name: 'USERNAME', value: "maintenance-mode"),
-            string(name: 'ICON', value: icon),
-            string(name: 'JOB', value: "Toggle maintenance mode on ${STAGE}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
-            text(name: 'STAGE', value: "${STAGE}"),
-            text(name: 'STATUS', value: status),
-            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-          ]
-        }
+    dsl: |
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "maintenance-mode"),
+          string(name: 'ICON', value: icon),
+          string(name: 'JOB', value: "Toggle maintenance mode on ${STAGE}"),
+          string(name: 'CHANNEL', value: "#dm-release"),
+          text(name: 'STAGE', value: "${STAGE}"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
 
-        stage("Create PR") {
-          currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${MODE}"
-          node {
-            try {
-              if ("${MODE}" == "maintenance") {
-                sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "on" "${STAGE}"')
-              } else {
-                sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "off" "${STAGE}"')
-              }
-
-            } catch(e) {
-              currentBuild.result = 'ABORTED'
-              error('Stopping early - possibly no change in maintenance mode, or script failed.')
+      stage("Create PR") {
+        currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${MODE}"
+        node {
+          try {
+            if ("${MODE}" == "maintenance") {
+              sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "on" "${STAGE}"')
+            } else {
+              sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "off" "${STAGE}"')
             }
+
+          } catch(e) {
+            currentBuild.result = 'ABORTED'
+            error('Stopping early - possibly no change in maintenance mode, or script failed.')
           }
         }
+      }
 
-        stage('Deploy') {
-          milestone()
-          waitUntil {
-            try {
-              input(message: "1/2: Do not continue until the Pull Request toggling maintenance mode has been merged to master.")
-              input(message: "2/2: Have you definitely merged the dm-aws Pull Request? Great. Go ahead.")
-              return true
-            } catch(error) {
-              input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
-              return false
-            }
+      stage('Deploy') {
+        milestone()
+        waitUntil {
+          try {
+            input(message: "1/2: Do not continue until the Pull Request toggling maintenance mode has been merged to master.")
+            input(message: "2/2: Have you definitely merged the dm-aws Pull Request? Great. Go ahead.")
+            return true
+          } catch(error) {
+            input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
+            return false
           }
-          milestone()
-
-          build job: "release-app-paas", parameters: [
-            string(name: "STAGE", value: "${STAGE}"),
-            string(name: "APPLICATION_NAME", value: "router")
-          ]
         }
+        milestone()
 
-        stage("Notify Slack") {
-          notify_slack(':hammer_and_wrench:', 'SUCCESS')
-        }
+        build job: "release-app-paas", parameters: [
+          string(name: "STAGE", value: "${STAGE}"),
+          string(name: "APPLICATION_NAME", value: "router")
+        ]
+      }
+
+      stage("Notify Slack") {
+        notify_slack(':hammer_and_wrench:', 'SUCCESS')
+      }

--- a/job_definitions/publish_framework_application_guidance.yml
+++ b/job_definitions/publish_framework_application_guidance.yml
@@ -8,19 +8,18 @@
     triggers:
       - pollscm:
           cron: "* * * * *"
-    pipeline:
-      script: |
-        node {
-          stage('Prepare') {
-            git url: "git@github.com:alphagov/digitalmarketplace-framework-application-guidance.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
-            sh("rbenv install -s")
-            sh("gem install bundler --conservative")
-            sh("make requirements")
-          }
-
-          stage('Build and publish') {
-            sh("git config user.name 'Jenkins'")
-            sh("git config user.email '{{ jenkins_github_email }}'")
-            sh("make publish")
-          }
+    dsl: |
+      node {
+        stage('Prepare') {
+          git url: "git@github.com:alphagov/digitalmarketplace-framework-application-guidance.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+          sh("rbenv install -s")
+          sh("gem install bundler --conservative")
+          sh("make requirements")
         }
+
+        stage('Build and publish') {
+          sh("git config user.name 'Jenkins'")
+          sh("git config user.email '{{ jenkins_github_email }}'")
+          sh("make publish")
+        }
+      }

--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -22,65 +22,64 @@
       - string:
           name: RELEASE_NAME
           description: "Release name (eg 'release-42') to deploy. If blank, the current release will be re-deployed."
-    pipeline:
-      script: |
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-            parameters: [
-              string(name: 'USERNAME', value: "release-application-to-paas"),
-              string(name: 'ICON', value: icon),
-              string(name: 'JOB', value: "Release ${APPLICATION_NAME} to ${STAGE}"),
-              string(name: 'CHANNEL', value: "#dm-release"),
-              string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
-              text(name: 'STAGE', value: "${STAGE}"),
-              text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),
-              text(name: 'STATUS', value: status),
-              text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-            ]
-        }
+    dsl: |
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+          parameters: [
+            string(name: 'USERNAME', value: "release-application-to-paas"),
+            string(name: 'ICON', value: icon),
+            string(name: 'JOB', value: "Release ${APPLICATION_NAME} to ${STAGE}"),
+            string(name: 'CHANNEL', value: "#dm-release"),
+            string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
+            text(name: 'STAGE', value: "${STAGE}"),
+            text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),
+            text(name: 'STATUS', value: status),
+            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+          ]
+      }
 
-        try {
-          node {
-            git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+      try {
+        node {
+          git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
 
-            stage('Prepare') {
-              build job: "update-credentials"
-              currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
-              sh('make paas-clean')
-              sh('pyenv local 3.6.2 && make requirements')
-            }
+          stage('Prepare') {
+            build job: "update-credentials"
+            currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
+            sh('make paas-clean')
+            sh('pyenv local 3.6.2 && make requirements')
+          }
 
-            stage('Deploy') {
-              withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
-                paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
-                withEnv(paas_credentials.tokenize("\n")) {
-                  sh('make paas-login')
+          stage('Deploy') {
+            withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
+              paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+              withEnv(paas_credentials.tokenize("\n")) {
+                sh('make paas-login')
+              }
+
+              lock("paas-${STAGE}-${APPLICATION_NAME}-deploy") {
+                if ("$RELEASE_NAME" == "") {
+                  echo "No release specified. Detecting currently deployed release version of ${APPLICATION_NAME} ..."
+
+                  env.RELEASE_NAME = sh(script: '''cf app ${APPLICATION_NAME} | grep 'docker image' | cut -d ':' -f 3''', returnStdout: true).trim()
+
+                  echo "Current deployed version of ${APPLICATION_NAME}: ${RELEASE_NAME}"
+                  currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
                 }
 
-                lock("paas-${STAGE}-${APPLICATION_NAME}-deploy") {
-                  if ("$RELEASE_NAME" == "") {
-                    echo "No release specified. Detecting currently deployed release version of ${APPLICATION_NAME} ..."
-
-                    env.RELEASE_NAME = sh(script: '''cf app ${APPLICATION_NAME} | grep 'docker image' | cut -d ':' -f 3''', returnStdout: true).trim()
-
-                    echo "Current deployed version of ${APPLICATION_NAME}: ${RELEASE_NAME}"
-                    currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
-                  }
-
-                  sh("make ${STAGE} deploy-app")
-                }
+                sh("make ${STAGE} deploy-app")
               }
             }
           }
-
-          notify_slack(':sheep:', 'SUCCESS')
-
-        } catch(err) {
-            currentBuild.result = 'FAILURE'
-            echo "Error: ${err}"
-            notify_slack(':kaboom:', 'FAILED')
-        } finally {
-          node {
-            sh('make paas-clean')
-          }
         }
+
+        notify_slack(':sheep:', 'SUCCESS')
+
+      } catch(err) {
+          currentBuild.result = 'FAILURE'
+          echo "Error: ${err}"
+          notify_slack(':kaboom:', 'FAILED')
+      } finally {
+        node {
+          sh('make paas-clean')
+        }
+      }

--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -9,285 +9,284 @@
     triggers:
       - pollscm:
           cron: "* * * * *"
-    pipeline:
-      script: |
+    dsl: |
 
-        import jenkins.model.Jenkins
+      import jenkins.model.Jenkins
 
-        def tag_release(tag) {
+      def tag_release(tag) {
+        try {
+          sh("git config user.name 'Jenkins'")
+          sh("git config user.email '{{ jenkins_github_email }}'")
+          sh("git tag -a ${tag} -m ${tag}")
+          sh("git push origin ${tag} -f")
+        } catch(e) {
+          echo "${tag} tag already exists"
+        }
+      }
+
+      def run_functional_tests(stage) {
+        waitUntil {
           try {
-            sh("git config user.name 'Jenkins'")
-            sh("git config user.email '{{ jenkins_github_email }}'")
-            sh("git tag -a ${tag} -m ${tag}")
-            sh("git push origin ${tag} -f")
-          } catch(e) {
-            echo "${tag} tag already exists"
-          }
-        }
-
-        def run_functional_tests(stage) {
-          waitUntil {
-            try {
-              node {
-                build job: "functional-tests-${stage}"
-                return true
-              }
-            } catch(error) {
-              echo "Functional tests failed: ${error}"
-              script {
-                env.FAILED_TEST_ACTION = input message: 'Functional tests failed. Retry, skip or abort?',
-                  parameters: [
-                    [
-                      $class: 'ChoiceParameterDefinition',
-                      choices: 'Retry\nSkip',
-                      description: 'Failed functional tests action',
-                      name: 'action'
-                    ]
-                  ]
-              }
-              echo "Action chosen was ${env.FAILED_TEST_ACTION}"
-
-              if (env.FAILED_TEST_ACTION == 'Retry') {
-                echo "Retrying functional tests on ${stage}."
-                return false
-              }
-              if (env.FAILED_TEST_ACTION == 'Skip') {
-                input(message: "Do you swear on your eternal soul that you 100% know what you're doing and you really don't want to make the tests pass first?")
-                echo "Skipping failed functional tests on ${stage}."
-                return true
-              }
-            }
-          }
-        }
-
-        def run_visual_regression_tests(stage) {
-          def job_name = "visual-regression-${stage}"
-          def vr_job = null
-
-          waitUntil {
             node {
-              vr_job = build job: job_name, parameters: [
-                string(name: "COMMAND", value: "test"),
-              ], propagate: false
+              build job: "functional-tests-${stage}"
+              return true
             }
-
-            def vr_job_result = vr_job.result
-            def vr_job_number = vr_job.number
-            vr_job = null
-
-            if (vr_job_result == 'SUCCESS') {
-                return true
-            } else {
-              echo "Visual regression tests build result: ${vr_job_result}"
-
-              script {
-                env.FAILED_TEST_ACTION = input message: 'Visual regression tests failed. Retry, approve, bypass?', parameters: [
+          } catch(error) {
+            echo "Functional tests failed: ${error}"
+            script {
+              env.FAILED_TEST_ACTION = input message: 'Functional tests failed. Retry, skip or abort?',
+                parameters: [
                   [
                     $class: 'ChoiceParameterDefinition',
-                    choices: 'Retry\nApprove\nBypass',
-                    description: 'Failed visual regression tests action',
+                    choices: 'Retry\nSkip',
+                    description: 'Failed functional tests action',
                     name: 'action'
                   ]
                 ]
-              }
+            }
+            echo "Action chosen was ${env.FAILED_TEST_ACTION}"
 
-              echo "Action chosen was ${env.FAILED_TEST_ACTION}"
+            if (env.FAILED_TEST_ACTION == 'Retry') {
+              echo "Retrying functional tests on ${stage}."
+              return false
+            }
+            if (env.FAILED_TEST_ACTION == 'Skip') {
+              input(message: "Do you swear on your eternal soul that you 100% know what you're doing and you really don't want to make the tests pass first?")
+              echo "Skipping failed functional tests on ${stage}."
+              return true
+            }
+          }
+        }
+      }
 
-              if (env.FAILED_TEST_ACTION == 'Retry') {
-                echo "Retrying visual regression tests on ${stage}."
-                return false
+      def run_visual_regression_tests(stage) {
+        def job_name = "visual-regression-${stage}"
+        def vr_job = null
 
-              } else if (env.FAILED_TEST_ACTION == 'Approve') {
-                def test_job = Jenkins.instance.getItemByFullName(job_name)
-                def test_job_last_build_number = test_job.getLastBuild().getNumber()
-                test_job = null
+        waitUntil {
+          node {
+            vr_job = build job: job_name, parameters: [
+              string(name: "COMMAND", value: "test"),
+            ], propagate: false
+          }
 
-                echo "Build triggered by this pipeline run: ${vr_job_number}. Last build: ${test_job_last_build_number}"
+          def vr_job_result = vr_job.result
+          def vr_job_number = vr_job.number
+          vr_job = null
 
-                if (test_job_last_build_number == vr_job_number) {
-                  echo "Verified that the last visual regression job built was triggered by this pipeline. Approving."
-                  try {
-                    node {
-                      build job: job_name, parameters: [
-                        string(name: "COMMAND", value: "approve"),
-                      ]
-                    }
+          if (vr_job_result == 'SUCCESS') {
+              return true
+          } else {
+            echo "Visual regression tests build result: ${vr_job_result}"
 
-                  } catch(inside_error) {
-                    echo "Approving visual regression tests failed: ${inside_error}"
-                    return false
+            script {
+              env.FAILED_TEST_ACTION = input message: 'Visual regression tests failed. Retry, approve, bypass?', parameters: [
+                [
+                  $class: 'ChoiceParameterDefinition',
+                  choices: 'Retry\nApprove\nBypass',
+                  description: 'Failed visual regression tests action',
+                  name: 'action'
+                ]
+              ]
+            }
+
+            echo "Action chosen was ${env.FAILED_TEST_ACTION}"
+
+            if (env.FAILED_TEST_ACTION == 'Retry') {
+              echo "Retrying visual regression tests on ${stage}."
+              return false
+
+            } else if (env.FAILED_TEST_ACTION == 'Approve') {
+              def test_job = Jenkins.instance.getItemByFullName(job_name)
+              def test_job_last_build_number = test_job.getLastBuild().getNumber()
+              test_job = null
+
+              echo "Build triggered by this pipeline run: ${vr_job_number}. Last build: ${test_job_last_build_number}"
+
+              if (test_job_last_build_number == vr_job_number) {
+                echo "Verified that the last visual regression job built was triggered by this pipeline. Approving."
+                try {
+                  node {
+                    build job: job_name, parameters: [
+                      string(name: "COMMAND", value: "approve"),
+                    ]
                   }
 
-                  return true
-                } else {
-                  input(message: "Visual regression tests have run elsewhere since this pipeline triggered the job. They will be re-run here when you proceed.")
+                } catch(inside_error) {
+                  echo "Approving visual regression tests failed: ${inside_error}"
                   return false
                 }
-              } else if (env.FAILED_TEST_ACTION == 'Bypass') {
-                input(message: "Are you sure you want to bypass the visual regression tests? It's very likely you want to retry them (eg if a page failed to load) or approve them (if the changes you made were intentional or data related).")
-                echo "Skipping failed visual regression tests on ${stage}."
+
                 return true
-
+              } else {
+                input(message: "Visual regression tests have run elsewhere since this pipeline triggered the job. They will be re-run here when you proceed.")
+                return false
               }
+            } else if (env.FAILED_TEST_ACTION == 'Bypass') {
+              input(message: "Are you sure you want to bypass the visual regression tests? It's very likely you want to retry them (eg if a page failed to load) or approve them (if the changes you made were intentional or data related).")
+              echo "Skipping failed visual regression tests on ${stage}."
+              return true
+
             }
           }
         }
+      }
 
-        stage('Create release tag') {
-          node {
-            git url: "git@github.com:alphagov/digitalmarketplace-{{ application }}.git",
-                branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
-            releaseNumber = sh(
-                script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
-                returnStdout: true
-            ).trim()
+      stage('Create release tag') {
+        node {
+          git url: "git@github.com:alphagov/digitalmarketplace-{{ application }}.git",
+              branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+          releaseNumber = sh(
+              script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
+              returnStdout: true
+          ).trim()
 
-            if (releaseNumber == "") {
-                throw new Exception('Release number can not be found')
-            }
-
-            releaseName = "release-${releaseNumber}"
-
-            tag_release(releaseName)
-
-            echo "Release number: ${releaseNumber}"
-            currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
+          if (releaseNumber == "") {
+              throw new Exception('Release number can not be found')
           }
-        }
 
-        stage('Build') {
-          node {
-            build job: "build-image", parameters: [
-              string(name: "REPOSITORY", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
-        }
+          releaseName = "release-${releaseNumber}"
 
-        {% if application in dm_db_applications %}
-        stage('DB migration on preview') {
-          node {
-            build job: "database-migration-paas", parameters: [
-              string(name: "STAGE", value: "preview"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
-        }
+          tag_release(releaseName)
 
-        stage('Functional tests - preview') {
-          milestone()
-          run_functional_tests("preview")
-          milestone()
+          echo "Release number: ${releaseNumber}"
+          currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
         }
+      }
+
+      stage('Build') {
+        node {
+          build job: "build-image", parameters: [
+            string(name: "REPOSITORY", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }
+
+      {% if application in dm_db_applications %}
+      stage('DB migration on preview') {
+        node {
+          build job: "database-migration-paas", parameters: [
+            string(name: "STAGE", value: "preview"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }
+
+      stage('Functional tests - preview') {
+        milestone()
+        run_functional_tests("preview")
+        milestone()
+      }
+      {% endif %}
+
+      stage('Release to preview') {
+        node {
+          build job: "release-app-paas", parameters: [
+            string(name: "STAGE", value: "preview"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+          build job: "tag-application-deloyment", parameters: [
+            string(name: "STAGE", value: "preview"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }
+
+      stage('Functional tests - preview') {
+        milestone()
+        run_functional_tests("preview")
+        milestone()
+      }
+
+      stage('Visual regression tests - preview') {
+        milestone()
+        run_visual_regression_tests("preview")
+        milestone()
+      }
+
+      {% if application in dm_db_applications %}
+      stage('DB migration on staging') {
+        milestone()
+        input(message: "Release to staging?")
+        milestone()
+        node {
+          build job: "database-migration-paas", parameters: [
+            string(name: "STAGE", value: "staging"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }
+
+      stage('Functional tests - staging') {
+        milestone()
+        run_functional_tests("staging")
+        milestone()
+      }
+      {% endif %}
+
+      stage('Release to staging') {
+        {% if application not in dm_db_applications %}
+        milestone()
+        input(message: "Release to staging?")
+        milestone()
         {% endif %}
-
-        stage('Release to preview') {
-          node {
-            build job: "release-app-paas", parameters: [
-              string(name: "STAGE", value: "preview"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-            build job: "tag-application-deloyment", parameters: [
-              string(name: "STAGE", value: "preview"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
+        node {
+          build job: "release-app-paas", parameters: [
+            string(name: "STAGE", value: "staging"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+          build job: "tag-application-deloyment", parameters: [
+            string(name: "STAGE", value: "staging"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
         }
+      }
 
-        stage('Functional tests - preview') {
-          milestone()
-          run_functional_tests("preview")
-          milestone()
-        }
+      stage('Functional tests - staging') {
+        milestone()
+        run_functional_tests("staging")
+        milestone()
+      }
 
-        stage('Visual regression tests - preview') {
-          milestone()
-          run_visual_regression_tests("preview")
-          milestone()
+      {% if application in dm_db_applications %}
+      stage('DB migration on production') {
+        milestone()
+        input(message: "Release to production?")
+        milestone()
+        node {
+          build job: "database-migration-paas", parameters: [
+            string(name: "STAGE", value: "production"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
         }
+      }
+      {% endif %}
 
-        {% if application in dm_db_applications %}
-        stage('DB migration on staging') {
-          milestone()
-          input(message: "Release to staging?")
-          milestone()
-          node {
-            build job: "database-migration-paas", parameters: [
-              string(name: "STAGE", value: "staging"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
-        }
-
-        stage('Functional tests - staging') {
-          milestone()
-          run_functional_tests("staging")
-          milestone()
-        }
+      stage('Release to production') {
+        {% if application not in dm_db_applications %}
+        milestone()
+        input(message: "Release to production?")
+        milestone()
         {% endif %}
-
-        stage('Release to staging') {
-          {% if application not in dm_db_applications %}
-          milestone()
-          input(message: "Release to staging?")
-          milestone()
-          {% endif %}
-          node {
-            build job: "release-app-paas", parameters: [
-              string(name: "STAGE", value: "staging"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-            build job: "tag-application-deloyment", parameters: [
-              string(name: "STAGE", value: "staging"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
+        node {
+          build job: "release-app-paas", parameters: [
+            string(name: "STAGE", value: "production"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+          build job: "tag-application-deloyment", parameters: [
+            string(name: "STAGE", value: "production"),
+            string(name: "APPLICATION_NAME", value: "{{ application }}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
         }
-
-        stage('Functional tests - staging') {
-          milestone()
-          run_functional_tests("staging")
-          milestone()
-        }
-
-        {% if application in dm_db_applications %}
-        stage('DB migration on production') {
-          milestone()
-          input(message: "Release to production?")
-          milestone()
-          node {
-            build job: "database-migration-paas", parameters: [
-              string(name: "STAGE", value: "production"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
-        }
-        {% endif %}
-
-        stage('Release to production') {
-          {% if application not in dm_db_applications %}
-          milestone()
-          input(message: "Release to production?")
-          milestone()
-          {% endif %}
-          node {
-            build job: "release-app-paas", parameters: [
-              string(name: "STAGE", value: "production"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-            build job: "tag-application-deloyment", parameters: [
-              string(name: "STAGE", value: "production"),
-              string(name: "APPLICATION_NAME", value: "{{ application }}"),
-              string(name: "RELEASE_NAME", value: "${releaseName}"),
-            ]
-          }
-        }
+      }
 {% endfor %}

--- a/job_definitions/rerelease_all.yml
+++ b/job_definitions/rerelease_all.yml
@@ -30,44 +30,43 @@
             - preview
             - staging
             - production
-    pipeline:
-      script: |
-        def notify_slack(icon, job, status) {
-          build job: "notify-slack",
-          parameters: [
-            string(name: 'USERNAME', value: "rerelease-all-apps"),
-            string(name: 'ICON', value: icon),
-            string(name: 'JOB', value: job),
-            string(name: 'CHANNEL', value: "#dm-release"),
-            text(name: 'STAGE', value: "${STAGE}"),
-            text(name: 'STATUS', value: status),
-            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-          ]
+    dsl: |
+      def notify_slack(icon, job, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "rerelease-all-apps"),
+          string(name: 'ICON', value: icon),
+          string(name: 'JOB', value: job),
+          string(name: 'CHANNEL', value: "#dm-release"),
+          text(name: 'STAGE', value: "${STAGE}"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
+      currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
+      notify_slack(':spinner:', 'Start re-release all apps on ${STAGE}', 'STARTED')
+      try {
+        stage('Update credentials') {
+          build job: "update-credentials"
         }
-        currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
-        notify_slack(':spinner:', 'Start re-release all apps on ${STAGE}', 'STARTED')
-        try {
-          stage('Update credentials') {
-            build job: "update-credentials"
-          }
-          parallel(
-  {% for app in apps %}
-            "{{ app }}": {
-              stage("{{ app }}") {
-                build job: "release-app-paas", parameters: [
-                  string(name: "STAGE", value: "${STAGE}"),
-                  string(name: "APPLICATION_NAME", value: "{{ app }}")
-                ]
-              }
-            },
-  {% endfor %}
-          )
+        parallel(
+{% for app in apps %}
+          "{{ app }}": {
+            stage("{{ app }}") {
+              build job: "release-app-paas", parameters: [
+                string(name: "STAGE", value: "${STAGE}"),
+                string(name: "APPLICATION_NAME", value: "{{ app }}")
+              ]
+            }
+          },
+{% endfor %}
+        )
 
-          stage("Notify Slack") {
-            notify_slack(':rocket:', 'Re-release all apps on ${STAGE}', 'SUCCESS')
-          }
-        } catch(e) {
-          currentBuild.result = 'FAILURE'
-          echo "Error: ${e}"
-          notify_slack(':boom:', 'Re-release all apps on ${STAGE}', 'FAILED')
+        stage("Notify Slack") {
+          notify_slack(':rocket:', 'Re-release all apps on ${STAGE}', 'SUCCESS')
         }
+      } catch(e) {
+        currentBuild.result = 'FAILURE'
+        echo "Error: ${e}"
+        notify_slack(':boom:', 'Re-release all apps on ${STAGE}', 'FAILED')
+      }

--- a/job_definitions/rotate_api_tokens.yml
+++ b/job_definitions/rotate_api_tokens.yml
@@ -26,20 +26,19 @@
             - preview
             - staging
             - production
-    pipeline:
-      script: |
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-          parameters: [
-            string(name: 'USERNAME', value: "rotate-api-tokens"),
-            string(name: 'ICON', value: icon),
-            string(name: 'JOB', value: "Rotate API tokens on ${STAGE}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
-            text(name: 'STAGE', value: "${STAGE}"),
-            text(name: 'STATUS', value: status),
-            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-          ]
-        }
+    dsl: |
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "rotate-api-tokens"),
+          string(name: 'ICON', value: icon),
+          string(name: 'JOB', value: "Rotate API tokens on ${STAGE}"),
+          string(name: 'CHANNEL', value: "#dm-release"),
+          text(name: 'STAGE', value: "${STAGE}"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
 
 {% for stage in stages %}
         stage("{{ stage.name }}") {

--- a/job_definitions/rotate_callback_token.yml
+++ b/job_definitions/rotate_callback_token.yml
@@ -10,20 +10,19 @@
     project-type: pipeline
     description: Rotate the {{ environment }} Notify callback token.
     concurrent: false
-    pipeline:
-      script: |
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-          parameters: [
-            string(name: 'USERNAME', value: "rotate-api-tokens"),
-            string(name: 'ICON', value: icon),
-            string(name: 'JOB', value: "Rotate Notify callback token for {{ environment }}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
-            text(name: 'STAGE', value: "{{ environment }}"),
-            text(name: 'STATUS', value: status),
-            text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
-          ]
-        }
+    dsl: |
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "rotate-api-tokens"),
+          string(name: 'ICON', value: icon),
+          string(name: 'JOB', value: "Rotate Notify callback token for {{ environment }}"),
+          string(name: 'CHANNEL', value: "#dm-release"),
+          text(name: 'STAGE', value: "{{ environment }}"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
 
 {% for job_stage in job_stages %}
         stage("{{ job_stage.name }}") {

--- a/job_definitions/smoke_tests.yml
+++ b/job_definitions/smoke_tests.yml
@@ -25,109 +25,108 @@
       - timed: "H/5 * * * *"
     wrappers:
       - ansicolor
-    pipeline:
-      script: |
+    dsl: |
 
-        def notify_slack(icon, status) {
-          build job: "notify-slack",
-                parameters: [
-                  string(name: 'USERNAME', value: 'smoke-tests'),
-                  string(name: 'ICON', value: icon),
-                  string(name: 'JOB', value: "Apps are up - {{ environment }}"),
-                  string(name: 'CHANNEL', value: "#dm-release"),
-                  text(name: 'STAGE', value: "{{ environment }}"),
-                  text(name: 'STATUS', value: status),
-                  text(name: 'URL', value: "<${BUILD_URL}smoke_test_report|${BUILD_DISPLAY_NAME}>")
-                ]
-        }
-        node {
+      def notify_slack(icon, status) {
+        build job: "notify-slack",
+              parameters: [
+                string(name: 'USERNAME', value: 'smoke-tests'),
+                string(name: 'ICON', value: icon),
+                string(name: 'JOB', value: "Apps are up - {{ environment }}"),
+                string(name: 'CHANNEL', value: "#dm-release"),
+                text(name: 'STAGE', value: "{{ environment }}"),
+                text(name: 'STATUS', value: status),
+                text(name: 'URL', value: "<${BUILD_URL}smoke_test_report|${BUILD_DISPLAY_NAME}>")
+              ]
+      }
+      node {
+        try {
+          stage('Prepare') {
+            git url: 'git@github.com:alphagov/digitalmarketplace-functional-tests.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
+            sh("rbenv install -s")
+            sh("gem install bundler --conservative")
+          }
+          stage('Run smoke tests') {
+            sh('''
+              set +x # do not echo credentials - remove for debugging
+
+              export DM_API_DOMAIN="{{ app_urls[environment].data_api }}"
+              export DM_API_ACCESS_TOKEN="$DM_DATA_API_TOKEN_{{ environment|upper }}"
+
+              export DM_SEARCH_API_DOMAIN="{{ app_urls[environment].search_api }}"
+              export DM_SEARCH_API_ACCESS_TOKEN="$DM_SEARCH_API_TOKEN_{{ environment|upper }}"
+
+              export DM_ANTIVIRUS_API_DOMAIN="{{ app_urls[environment].antivirus_api }}"
+
+              export DM_FRONTEND_DOMAIN="{{ app_urls[environment].www }}"
+
+              export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
+              export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[environment].supplier_password }}"
+              export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ smoke_test_variables[environment].supplier_id }}"
+
+              export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
+              export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
+
+              export DM_PRODUCTION_ADMIN_USER_EMAIL="{{ smoke_test_variables[environment].admin_email }}"
+              export DM_PRODUCTION_ADMIN_USER_PASSWORD="{{ smoke_test_variables[environment].admin_password }}"
+
+              export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_category_email }}"
+              export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_category_password }}"
+
+              export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
+              export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
+
+              export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
+              export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
+
+              export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
+              export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
+
+              set -x # restore echo
+
+              export DM_PAGINATION_LIMIT=100
+
+              export DM_ENVIRONMENT={{ environment }}
+
+              make smoke-tests || make rerun
+            ''')
+
+            if (currentBuild.rawBuild.getCause(hudson.model.Cause$UpstreamCause) != null) {
+              notify_slack(':green_heart:', 'SUCCESS')
+            }
+          }
+        } catch(err) {
+        {% if environment == 'production' %}
+          notify_slack(':fire:', 'FAILED')
+        {% else %}
           try {
-            stage('Prepare') {
-              git url: 'git@github.com:alphagov/digitalmarketplace-functional-tests.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
-              sh("rbenv install -s")
-              sh("gem install bundler --conservative")
-            }
-            stage('Run smoke tests') {
-              sh('''
-                set +x # do not echo credentials - remove for debugging
+            def migrations_being_run = sh(
+              script: "curl -s http://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@localhost:80/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
+              returnStdout: true
+            ).trim()
 
-                export DM_API_DOMAIN="{{ app_urls[environment].data_api }}"
-                export DM_API_ACCESS_TOKEN="$DM_DATA_API_TOKEN_{{ environment|upper }}"
-
-                export DM_SEARCH_API_DOMAIN="{{ app_urls[environment].search_api }}"
-                export DM_SEARCH_API_ACCESS_TOKEN="$DM_SEARCH_API_TOKEN_{{ environment|upper }}"
-
-                export DM_ANTIVIRUS_API_DOMAIN="{{ app_urls[environment].antivirus_api }}"
-
-                export DM_FRONTEND_DOMAIN="{{ app_urls[environment].www }}"
-
-                export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
-                export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[environment].supplier_password }}"
-                export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ smoke_test_variables[environment].supplier_id }}"
-
-                export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
-                export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
-
-                export DM_PRODUCTION_ADMIN_USER_EMAIL="{{ smoke_test_variables[environment].admin_email }}"
-                export DM_PRODUCTION_ADMIN_USER_PASSWORD="{{ smoke_test_variables[environment].admin_password }}"
-
-                export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_category_email }}"
-                export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_category_password }}"
-
-                export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
-                export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
-
-                export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
-                export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
-
-                export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
-                export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
-
-                set -x # restore echo
-
-                export DM_PAGINATION_LIMIT=100
-
-                export DM_ENVIRONMENT={{ environment }}
-
-                make smoke-tests || make rerun
-              ''')
-
-              if (currentBuild.rawBuild.getCause(hudson.model.Cause$UpstreamCause) != null) {
-                notify_slack(':green_heart:', 'SUCCESS')
-              }
-            }
-          } catch(err) {
-          {% if environment == 'production' %}
-            notify_slack(':fire:', 'FAILED')
-          {% else %}
-            try {
-              def migrations_being_run = sh(
-                script: "curl -s http://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@localhost:80/job/clean-and-apply-db-dump-{{ environment }}/lastBuild/api/json?tree=building | jq -r '.building'",
-                returnStdout: true
-              ).trim()
-
-              if (migrations_being_run == 'false') {
-                notify_slack(':fire:', 'FAILED')
-              }
-            } catch(err2) {
+            if (migrations_being_run == 'false') {
               notify_slack(':fire:', 'FAILED')
             }
-          {% endif %}
-
-            echo "Error caught"
-            currentBuild.result = 'FAILURE'
-            echo "Error: ${err}"
-          } finally {
-            publishHTML(target: [
-              allowMissing: true,
-              alwaysLinkToLastBuild: true,
-              keepAll: true,
-              reportDir: 'reports',
-              reportFiles: 'index.html',
-              reportName: 'smoke test report'
-            ])
+          } catch(err2) {
+            notify_slack(':fire:', 'FAILED')
           }
+        {% endif %}
+
+          echo "Error caught"
+          currentBuild.result = 'FAILURE'
+          echo "Error: ${err}"
+        } finally {
+          publishHTML(target: [
+            allowMissing: true,
+            alwaysLinkToLastBuild: true,
+            keepAll: true,
+            reportDir: 'reports',
+            reportFiles: 'index.html',
+            reportName: 'smoke test report'
+          ])
         }
+      }
 
 
 

--- a/job_definitions/tag_application_deployment.yml
+++ b/job_definitions/tag_application_deployment.yml
@@ -23,23 +23,22 @@
       - string:
           name: RELEASE_NAME
           description: "Release name (eg 'release-42') to deploy"
-    pipeline:
-      script: |
-        node {
-          stage('Pull repo') {
-            dir("${APPLICATION_NAME}") {
-              git url: 'git@github.com:alphagov/digitalmarketplace-${APPLICATION_NAME}.git',
-                  branch: 'master',
-                  credentialsId: 'github_com_and_enterprise'
-            }
-          }
-
-          stage('Move release tag') {
-            dir("${APPLICATION_NAME}") {
-              sh("git config user.name 'Jenkins'")
-              sh("git config user.email '{{ jenkins_github_email }}'")
-              sh("git tag -a -f -m deployed-to-${STAGE} deployed-to-${STAGE} ${RELEASE_NAME}" )
-              sh("git push --force origin refs/tags/deployed-to-${STAGE}:refs/tags/deployed-to-${STAGE}")
-            }
+    dsl: |
+      node {
+        stage('Pull repo') {
+          dir("${APPLICATION_NAME}") {
+            git url: 'git@github.com:alphagov/digitalmarketplace-${APPLICATION_NAME}.git',
+                branch: 'master',
+                credentialsId: 'github_com_and_enterprise'
           }
         }
+
+        stage('Move release tag') {
+          dir("${APPLICATION_NAME}") {
+            sh("git config user.name 'Jenkins'")
+            sh("git config user.email '{{ jenkins_github_email }}'")
+            sh("git tag -a -f -m deployed-to-${STAGE} deployed-to-${STAGE} ${RELEASE_NAME}" )
+            sh("git push --force origin refs/tags/deployed-to-${STAGE}:refs/tags/deployed-to-${STAGE}")
+          }
+        }
+      }

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -28,22 +28,21 @@
           description: >
             If there is an index with the alias '<alias>-old' and
             this option is enabled then that index will be deleted.
-    pipeline:
-      script: |
-        node {
-          stage('Update alias'){
-            sh('''
-              docker run \
-                -e "DM_SEARCH_API_TOKEN_{{ environment|upper }}" \
-                -e "DM_DATA_API_TOKEN_{{ environment|upper }}" \
-                digitalmarketplace/scripts \
-                scripts/update-index-alias.py \
-                "${ALIAS}" \
-                "${TARGET}" \
-                "{{ app_urls[environment].search_api }}" \
-                --stage="{{ environment }}" \
-                --delete-old-index=${DELETE_OLD_INDEX}
-            ''')
-          }
+    dsl: |
+      node {
+        stage('Update alias'){
+          sh('''
+            docker run \
+              -e "DM_SEARCH_API_TOKEN_{{ environment|upper }}" \
+              -e "DM_DATA_API_TOKEN_{{ environment|upper }}" \
+              digitalmarketplace/scripts \
+              scripts/update-index-alias.py \
+              "${ALIAS}" \
+              "${TARGET}" \
+              "{{ app_urls[environment].search_api }}" \
+              --stage="{{ environment }}" \
+              --delete-old-index=${DELETE_OLD_INDEX}
+          ''')
         }
+      }
 {% endfor %}

--- a/playbooks/roles/jenkins/tasks/jobs.yml
+++ b/playbooks/roles/jenkins/tasks/jobs.yml
@@ -5,10 +5,7 @@
 
 - name: copy a requirements file with pinned Python dependencies
   copy:
-    content: |
-      python-jenkins==0.4.15  # newer ones have broken basic auth :(
-      jenkins-job-builder==1.6.2
-      git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline
+    src: ../../../../requirements-jenkins-job-builder.txt
     dest: /tmp/jenkins-jobs-python-requirements.txt
     force: yes
 

--- a/requirements-jenkins-job-builder.txt
+++ b/requirements-jenkins-job-builder.txt
@@ -1,0 +1,3 @@
+python-jenkins==0.4.15  # newer ones have broken basic auth :(
+jenkins-job-builder==1.6.2
+git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline

--- a/requirements-jenkins-job-builder.txt
+++ b/requirements-jenkins-job-builder.txt
@@ -1,3 +1,2 @@
 python-jenkins==0.4.15  # newer ones have broken basic auth :(
-jenkins-job-builder==1.6.2
-git+https://github.com/rusty-dev/jenkins-job-builder-pipeline.git@f24b9f5b0de03edd59b94061fa5182d11887403d#egg=jenkins_job_builder_pipeline
+jenkins-job-builder==2.6.0


### PR DESCRIPTION
This PR updates Jenkins Job Builder to the latest stable version, closing the outstanding [Trello ticket].

Only small changes were required to the job definition files (changing the `pipeline: script` key to `dsl`), the main blocker was the interaction between jenkins-job-builder and jenkins-job-builder-pipeline. It turns out that having jenkins-job-builder-pipeline with later versions of jenkins-job-builder will cause pipeline job definitions to fail. This was fixed by adding a task to the Ansible playbook to ensure that jenkins-job-builder-pipeline is uninstalled from the system Python environment.

These changes have now been manually tested on the Jenkins box.

[Trello ticket]: https://trello.com/c/pSEUci7F/103-upgrade-jenkins-job-builder-to-220