### PR TITLE
JJB tests: nix fix, change `make` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,10 @@ requirements: venv ## Install requirements
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
 
 .PHONY: requirements-test
-requirements-test: requirements ## Install test requirements
+requirements-test: requirements-dev ## Alias for backwards-compatibility
+
+.PHONY: requirements-dev
+requirements-dev: requirements ## Install test requirements
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements-jenkins-job-builder.txt
 
 .PHONY: clean

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@ let
   args = rec {
     pkgs = import <nixpkgs> {};
     pythonPackages = pkgs.python36Packages;
+    forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
 in (with args; {
@@ -24,6 +25,8 @@ in (with args; {
       # ansible makes use of rsync & ssh
       pkgs.openssh
       pkgs.rsync
+      # for tput
+      pkgs.ncurses
       ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
     ];
 
@@ -45,7 +48,7 @@ in (with args; {
       fi
       source $VIRTUALENV_ROOT/bin/activate
       pip install --upgrade pip==18.0  # e.g. pynacl is sensitive to "old" pips
-      make requirements
+      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
   }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })


### PR DESCRIPTION
Just a quick fix for `default.nix` but also changing the target `make requirements-test` to `make requirements-dev` just for uniformity with other repos. Left `requirements-test` in as an alias so this doesn't trip anyone up when introduced.