### PR TITLE
Fix bug in test_templates.sh

### DIFF
--- a/tests/test_templates.sh
+++ b/tests/test_templates.sh
@@ -39,15 +39,9 @@ main()
 	copy_jjb_config "jenkins_jobs.ini"
 	colorecho "done"
 
-	for job_file in job_definitions/*.yml
-	do
-		colorecho "Parsing '$job_file' with jenkins-jobs..."
-		run_jjb "job_definitions" "$job_file"
-		STATUS=$((STATUS|$?))
-		colorecho "done"
-	done
+	run_jjb "job_definitions" "job_definitions"
 
-	colorecho "jjb-lint finished with status code $STATUS"
+	colorecho "$0 finished with status code $STATUS"
 	exit $STATUS
 }
 


### PR DESCRIPTION
`test_templates.sh` was not using the global defaults because it was only parsing one jobfile at a time.

This commit changes the JJB run to include all templates at once, which more closely reflects the behaviour of the Jenkins Ansible role.

It does mean the output is slightly less helpful though.