### PR TITLE
Add Jenkins Audit Trail logging

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -75,6 +75,7 @@ jenkins_plugins:
   - workflow-aggregator  # aka 'Pipeline' suite
 
 jenkins_config_templates:
+  - audit-trail.xml
   - config.xml
   - credentials.xml
   - hudson.plugins.git.GitSCM.xml

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -55,6 +55,7 @@ dm_db_applications:
 
 jenkins_plugins:
   - ansicolor
+  - audit-trail
   - build-monitor-plugin
   - build-name-setter
   - conditional-buildstep

--- a/playbooks/roles/jenkins/templates/jenkins/audit-trail.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/audit-trail.xml.j2
@@ -1,0 +1,12 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.audit__trail.AuditTrailPlugin plugin="audit-trail@2.3">
+  <pattern>.*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)</pattern>
+  <logBuildCause>true</logBuildCause>
+  <loggers>
+    <hudson.plugins.audit__trail.LogFileAuditLogger>
+      <log>/var/log/jenkins/audit-trail.log</log>
+      <limit>50</limit>
+      <count>10</count>
+    </hudson.plugins.audit__trail.LogFileAuditLogger>
+  </loggers>
+</hudson.plugins.audit__trail.AuditTrailPlugin>

--- a/playbooks/roles/jenkins/templates/jenkins/audit-trail.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/audit-trail.xml.j2
@@ -1,6 +1,6 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <hudson.plugins.audit__trail.AuditTrailPlugin plugin="audit-trail@2.3">
-  <pattern>.*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)</pattern>
+  <pattern>.*/(?:configure|configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)</pattern>
   <logBuildCause>true</logBuildCause>
   <loggers>
     <hudson.plugins.audit__trail.LogFileAuditLogger>


### PR DESCRIPTION
This PR adds the Jenkins Audit Trail plugin so we can log events such as job start/stop, job editing, and credentials editing.

For more details, see the [Trello ticket][ticket].

Included in this PR is configuration for Audit Trail that logs the default set of events to the file `/var/log/jenkins/audit-trail.log`. The Jenkins logging infrastructure provides log rotation out of the box, for audit logs it's been configured for up to 10 files of 50 MiB each.

An example of the log output is provided below.

```
Nov 27, 2018 12:41:01,434 PM job/functional-tests-preview/ #20658 Started by user Laurence de Bruxelles
Nov 27, 2018 12:41:58,584 PM /job/performance-testing-buyer-app/configSubmit by lfdebrux
Nov 27, 2018 12:42:08,211 PM /job/performance-testing-buyer-app/doDelete by lfdebrux
Nov 27, 2018 12:44:00,877 PM job/apps-are-up-preview/ #33430 Started by timer
Nov 27, 2018 12:45:51,868 PM Functional tests - preview #20658 Started by user Laurence de Bruxelles on node Jenkins started at 2018-11-27T12:41:01Z completed in 290427ms completed: SUCCESS
Nov 27, 2018 12:46:00,858 PM job/notify-slack/ #1832 Started by upstream project "functional-tests-preview" build number 20,658
```

[ticket]: https://trello.com/c/fgGoc5HO/251-install-and-configure-jenkins-audittrail-logging

---

It also logs whenever anyone views the main Jenkins configuration page (thanks @benvand for the suggestion).