### PR TITLE
Add Jenkins access logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || echo ${VIRTUAL_ENV})
 
+export ANSIBLE_ROLES_PATH := ${VIRTUALENV_ROOT}/etc/ansible/roles
+export ANSIBLE_CONFIG := playbooks/ansible.cfg
+
 # extra variables that, if specified, will override those in playbooks/roles/jenkins/defaults/main.yml
 ifdef JOBS_DISABLED
 	EXTRA_VARS += -e 'jobs_disabled=${JOBS_DISABLED}'
@@ -23,6 +26,7 @@ ${VIRTUALENV_ROOT}/activate:
 .PHONY: requirements
 requirements: venv ## Install requirements
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
+	${VIRTUALENV_ROOT}/bin/ansible-galaxy install -r playbooks/requirements.yml
 
 .PHONY: requirements-test
 requirements-test: requirements-dev ## Alias for backwards-compatibility

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,0 +1,2 @@
+- src: nickhammond.logrotate
+  version: v0.0.5

--- a/playbooks/roles/jenkins/tasks/jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/jenkins.yml
@@ -30,6 +30,22 @@
             dest=/etc/default/jenkins
             backup=no
 
+- name: Configure Jenkins log rotation
+  include_role:
+    name: nickhammond.logrotate
+  vars:
+    logrotate_scripts:
+      - name: jenkins
+        path: /var/log/jenkins/access.log
+        options:
+          - weekly
+          - copytruncate
+          - missingok
+          - rotate 52
+          - compress
+          - delaycompress
+          - notifempty
+
 - name: Ensure Jenkins is installed.
   apt:
     name=jenkins=2.*

--- a/playbooks/roles/jenkins/templates/jenkins_defaults.j2
+++ b/playbooks/roles/jenkins/templates/jenkins_defaults.j2
@@ -36,6 +36,9 @@ RUN_STANDALONE=true
 # log location.  this may be a syslog facility.priority
 JENKINS_LOG={{ jenkins_logs_dir }}/$NAME.log
 
+# enable access log; see https://wiki.jenkins.io/display/JENKINS/Access+Logging
+JENKINS_ACCESSLOG="--accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/jenkins/access.log"
+
 # OS LIMITS SETUP
 #   comment this out to observe /etc/security/limits.conf
 #   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e


### PR DESCRIPTION
Configure Jenkins to log HTTP access, following the instructions linked to in the [Trello ticket][ticket]. This gives us a very fine-grained event stream we can use for monitoring.

Example output:

```
213.86.153.212 - - [28/Nov/2018:10:12:32 +0000] "POST /ajaxBuildQueue HTTP/1.0" 200 703 "https://ci.marketplace.team/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
213.86.153.212 - - [28/Nov/2018:10:12:32 +0000] "POST /ajaxExecutors HTTP/1.0" 200 806 "https://ci.marketplace.team/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
213.86.153.212 - - [28/Nov/2018:10:12:34 +0000] "POST /$stapler/bound/49265b02-45f9-4ac3-bfa5-e0b055e7d264/fetchJobViews HTTP/1.0" 200 4408 "https://ci.marketplace.team/view/Build%20Monitor/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:62.0) Gecko/20100101 Firefox/62.0"
```

Note that IP addresses are client addresses, not the load balancer address 😁

[ticket]: https://trello.com/c/yOxnYGPb/252-configure-jenkins-access-logging

---

### Ansible Galaxy

As part of the configuration for the access logging an external role was used, [nickhammond.logrotate](https://github.com/nickhammond/ansible-logrotate). This PR includes commits that adds a step to the Makefile to install Ansible Galaxy requirements, as part of the `requirements` recipe.