### PR TITLE
Enable SSH access logging on Jenkins box

### DIFF
--- a/playbooks/jenkins_playbook.yml
+++ b/playbooks/jenkins_playbook.yml
@@ -11,4 +11,5 @@
     sshd:
       ClientAliveCountMax: 80
       ClientAliveInterval: 45
+      LogLevel: VERBOSE
       PasswordAuthentication: no

--- a/playbooks/jenkins_playbook.yml
+++ b/playbooks/jenkins_playbook.yml
@@ -5,3 +5,10 @@
   become: yes
   roles:
     - jenkins
+    - role: willshersystems.sshd
+      tags: [sshd, jenkins]
+  vars:
+    sshd:
+      ClientAliveCountMax: 80
+      ClientAliveInterval: 45
+      PasswordAuthentication: no

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,2 +1,4 @@
 - src: nickhammond.logrotate
   version: v0.0.5
+- src: willshersystems.sshd
+  version: v0.7.2

--- a/playbooks/roles/jenkins/tasks/bootstrap.yml
+++ b/playbooks/roles/jenkins/tasks/bootstrap.yml
@@ -17,22 +17,5 @@
 - name: Create logs dir
   file: path={{ jenkins_logs_dir }} mode=755 state=directory owner=jenkins
 
-- name: Set SSH ClientAliveInterval
-  lineinfile:
-    path: /etc/ssh/sshd_config
-    line: "ClientAliveInterval 45"
-    regexp: "^ClientAliveInterval (\\d*)$"
-
-- name: Set SSH ClientAliveCountMax
-  lineinfile:
-    path: /etc/ssh/sshd_config
-    line: "ClientAliveCountMax 80"
-    regexp: "^ClientAliveCountMax (\\d*)$"
-
-- name: Restart sshd
-  service:
-      name: 'ssh'
-      state: 'restarted'
-
 - set_fact:
     jobs_disabled: true  # when first setting up a box, disable the jobs!


### PR DESCRIPTION
This PR is part of this [ticket] to enable Jenkins SSH access logging.

Although the logging provided by the SSH daemon is less useful than logging at the load balancer in that it doesn't record client IP addresses, I still think it's useful to capture the SSH session details.

This PR adds an Ansible role to handle the SSHd configuration, and enables verbose logging to the file `/var/log/auth.log`.

Examples of log entries below:

```
Nov 22 11:15:18 ip-172-31-14-48 sshd[23708]: Postponed publickey for ubuntu from 172.31.6.132 port 4212 ssh2 [preauth]
Nov 22 11:15:18 ip-172-31-14-48 sshd[23708]: Accepted publickey for ubuntu from 172.31.6.132 port 4212 ssh2: RSA SHA256:deadbeef/redactedbeef
Nov 22 11:15:18 ip-172-31-14-48 sshd[23708]: pam_unix(sshd:session): session opened for user ubuntu by (uid=0)
Nov 22 11:15:18 ip-172-31-14-48 systemd-logind[1303]: New session 3797 of user ubuntu.
Nov 22 11:15:18 ip-172-31-14-48 systemd: pam_unix(systemd-user:session): session opened for user ubuntu by (uid=0)
Nov 22 11:15:18 ip-172-31-14-48 sshd[23708]: User child is on pid 23748
```

[ticket]: https://trello.com/c/S7iFoAU8/253-configure-jenkins-box-ssh-access-logging