### PR TITLE
Push Jenkins access logs to CloudWatch

### DIFF
--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,5 +1,6 @@
 [jenkins]
-ci.marketplace.team
+ci.marketplace.team ansible_user=ubuntu
 
 [jenkins:vars]
 ansible_python_interpreter=/usr/bin/python3
+ec2_region=eu-west-1

--- a/playbooks/jenkins_playbook.yml
+++ b/playbooks/jenkins_playbook.yml
@@ -10,6 +10,19 @@
     - role: singleplatform-eng.awslogs
       tags: [awslogs, jenkins]
   vars:
+    awslogs_config:
+      - file: /var/log/auth.log
+        datetime_format: "%b %d %H:%M:%S"
+        log_stream_name: jenkins-{instance_id}
+        log_group_name: server-login-access
+      - file: /var/log/jenkins/access.log
+        datetime_format: "%d/%b/%Y:%H:%M:%S %z"
+        log_stream_name: jenkins-{instance_id}
+        log_group_name: jenkins-access
+      - file: /var/log/jenkins/audit-trail.log.0
+        datetime_format: "%b %d, %Y %I:%M:%S,%f %p"
+        log_stream_name: jenkins-{instance_id}
+        log_group_name: jenkins-audit
     sshd:
       ClientAliveCountMax: 80
       ClientAliveInterval: 45

--- a/playbooks/jenkins_playbook.yml
+++ b/playbooks/jenkins_playbook.yml
@@ -7,6 +7,8 @@
     - jenkins
     - role: willshersystems.sshd
       tags: [sshd, jenkins]
+    - role: singleplatform-eng.awslogs
+      tags: [awslogs, jenkins]
   vars:
     sshd:
       ClientAliveCountMax: 80

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,4 +1,6 @@
 - src: nickhammond.logrotate
   version: v0.0.5
+- src: singleplatform-eng.awslogs
+  version: 1.0.2
 - src: willshersystems.sshd
   version: v0.7.2

--- a/playbooks/roles/jenkins/templates/jenkins_defaults.j2
+++ b/playbooks/roles/jenkins/templates/jenkins_defaults.j2
@@ -65,4 +65,4 @@ PREFIX=/jenkins
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 
-JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
+JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT $JENKINS_ACCESSLOG"


### PR DESCRIPTION
We want to have our Jenkins access logs to be backed up on AWS.

This PR achieves that by adding an ansible roles that installs and configures the AWS CloudWatch Logs Agent.

For the logs to be properly uploaded, the EC2 instance profile must include permissions for CloudWatch. This is done by alphagov/digitalmarketplace-aws#477.

See the [ticket] for more details on why CloudWatch and the CloudWatch Logs Agent were chosen.

[ticket]: https://trello.com/c/Uf14tLzG/247-jenkins-get-the-job-logs-out