### PR TITLE
release pipeline: attempt to opportunistically launch smoulder tests on prod after successful pipeline release

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -287,17 +287,7 @@
             string(name: "APPLICATION_NAME", value: "{{ application }}"),
             string(name: "RELEASE_NAME", value: "${releaseName}"),
           ]
-          try {
-            def smoulder_tests_queued = sh(
-              script: "curl -s http://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@localhost:80/queue/api/json | jq '.items | map(.task.name==\"apps-are-working-production\") | any'",
-              returnStdout: true
-            ).trim()
-            if (smoulder_tests_queued == 'false') {
-              build job: "apps-are-working-production", wait: false
-            }
-          } catch(err) {
-            echo "Failed attempting to determine if there are smoulder tests already queued: ${err}"
-          }
+          build job: "apps-are-working-production", wait: false
         }
       }
 {% endfor %}

--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -287,6 +287,17 @@
             string(name: "APPLICATION_NAME", value: "{{ application }}"),
             string(name: "RELEASE_NAME", value: "${releaseName}"),
           ]
+          try {
+            def smoulder_tests_queued = sh(
+              script: "curl -s http://{{ jenkins_api_user }}:{{ jenkins_api_user_github_personal_access_token }}@localhost:80/queue/api/json | jq '.items | map(.task.name==\"apps-are-working-production\") | any'",
+              returnStdout: true
+            ).trim()
+            if (smoulder_tests_queued == 'false') {
+              build job: "apps-are-working-production", wait: false
+            }
+          } catch(err) {
+            echo "Failed attempting to determine if there are smoulder tests already queued: ${err}"
+          }
         }
       }
 {% endfor %}


### PR DESCRIPTION
https://trello.com/c/y3rcfYeG/213-create-smoulder-tests-to-allow-more-thorough-tests-notably-antivirus-tests-to-be-run-on-production

The idea is that we get quicker feedback if something is wrong rather than
potentially having to wait up to an hour for them to be run automatically