### PR TITLE
data_retention job: add $MAILCHIMP_API_TOKEN argument to enable mailchimp list cleaning

### DIFF
--- a/job_definitions/data_retention.yml
+++ b/job_definitions/data_retention.yml
@@ -31,6 +31,10 @@
             FLAGS="--dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-user-data.py '{{ environment }}' $FLAGS --verbose
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-user-data.py '{{ environment }}' \
+            --mailchimp-username="jenkins" \
+            --mailchimp-api-key=$MAILCHIMP_API_TOKEN \
+            $FLAGS --verbose
+
           docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-contact-information-data.py '{{ environment }}' $FLAGS --verbose
 {% endfor %}


### PR DESCRIPTION
This should enable https://trello.com/c/QROOUpoX, but I shouldn't apply it until https://github.com/alphagov/digitalmarketplace-scripts/pull/327 is merged.