### PR TITLE
Change name of script called by notify-suppliers-of-dos-opportunities

### DIFF
--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -66,6 +66,6 @@
             FLAGS="$FLAGS --number_of_days=$NUMBER_OF_DAYS"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }} $FLAGS
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-dos-opportunities.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }} $FLAGS
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
We want to rename the script in the dmscripts repo, so we also need to update the job.

This PR depends on https://github.com/alphagov/digitalmarketplace-scripts/pull/328 and is part of https://trello.com/c/aRpNbH4o/309-rename-send-dos-opportunities-emailpy-to-notify-suppliers-something-somethingpy