### PR TITLE
Add git trigger to build_base_docker_images job

### DIFF
--- a/job_definitions/build_base_docker_images.yml
+++ b/job_definitions/build_base_docker_images.yml
@@ -4,11 +4,13 @@
     project-type: pipeline
     triggers:
       - timed: "H 0 * * MON,THU,SAT"
+      - pollscm:
+        cron: "* * * * *"
     dsl: |
       node {
         try {
           stage('Prepare') {
-            git url: "git@github.com:alphagov/digitalmarketplace-docker-base.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+            git url: "git@github.com:alphagov/digitalmarketplace-docker-base.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
           }
           stage('Build') {
             sh("make build")


### PR DESCRIPTION
We want to get a new version of the Docker base images on DockerHub when we update the Dockerfiles on GitHub.

Closes https://trello.com/c/SxUdIIy3/314-automatic-push-to-docker-hub