### PR TITLE
Remove references to production users from envvars

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -79,6 +79,28 @@
 
           export DM_NOTIFY_API_KEY="$NOTIFY_API_FUNCTIONAL_TESTS_KEY_{{ job.environment|upper }}"
 
+          export DM_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[job.environment].supplier_email }}"
+          export DM_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[job.environment].supplier_password }}"
+          export DM_SUPPLIER_USER_SUPPLIER_ID="{{ smoke_test_variables[job.environment].supplier_id }}"
+
+          export DM_BUYER_USER_EMAIL="{{ smoke_test_variables[job.environment].buyer_email }}"
+          export DM_BUYER_USER_PASSWORD="{{ smoke_test_variables[job.environment].buyer_password }}"
+
+          export DM_ADMIN_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_email }}"
+          export DM_ADMIN_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_password }}"
+
+          export DM_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_category_email }}"
+          export DM_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_category_password }}"
+
+          export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_email }}"
+          export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_password }}"
+
+          export DM_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_manager_email }}"
+          export DM_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_manager_password }}"
+
+          export DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
+          export DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
+
           export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[job.environment].supplier_email }}"
           export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[job.environment].supplier_password }}"
           export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ smoke_test_variables[job.environment].supplier_id }}"

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -101,28 +101,6 @@
           export DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
           export DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
 
-          export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[job.environment].supplier_email }}"
-          export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[job.environment].supplier_password }}"
-          export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ smoke_test_variables[job.environment].supplier_id }}"
-
-          export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[job.environment].buyer_email }}"
-          export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[job.environment].buyer_password }}"
-
-          export DM_PRODUCTION_ADMIN_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_email }}"
-          export DM_PRODUCTION_ADMIN_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_password }}"
-
-          export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_category_email }}"
-          export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_category_password }}"
-
-          export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_email }}"
-          export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_password }}"
-
-          export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_manager_email }}"
-          export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_manager_password }}"
-
-          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_framework_manager_email }}"
-          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_framework_manager_password }}"
-
           export DM_DOCUMENTS_BUCKET_NAME="digitalmarketplace-documents-{{ job.environment }}-{{ job.environment }}"
 
           set -x # restore echo

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -106,6 +106,28 @@
 
               export DM_FRONTEND_DOMAIN="{{ app_urls[environment].www }}"
 
+              export DM_SUPPLIER_USER_EMAIL="{{ instance.vars.supplier_email }}"
+              export DM_SUPPLIER_USER_PASSWORD="{{ instance.vars.supplier_password }}"
+              export DM_SUPPLIER_USER_SUPPLIER_ID="{{ instance.vars.supplier_id }}"
+
+              export DM_BUYER_USER_EMAIL="{{ instance.vars.buyer_email }}"
+              export DM_BUYER_USER_PASSWORD="{{ instance.vars.buyer_password }}"
+
+              export DM_ADMIN_USER_EMAIL="{{ instance.vars.admin_email }}"
+              export DM_ADMIN_USER_PASSWORD="{{ instance.vars.admin_password }}"
+
+              export DM_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ instance.vars.admin_ccs_category_email }}"
+              export DM_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ instance.vars.admin_ccs_category_password }}"
+
+              export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ instance.vars.admin_ccs_sourcing_email }}"
+              export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ instance.vars.admin_ccs_sourcing_password }}"
+
+              export DM_ADMIN_MANAGER_USER_EMAIL="{{ instance.vars.admin_manager_email }}"
+              export DM_ADMIN_MANAGER_USER_PASSWORD="{{ instance.vars.admin_manager_password }}"
+
+              export DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ instance.vars.admin_framework_manager_email }}"
+              export DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ instance.vars.admin_framework_manager_password }}"
+
               export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ instance.vars.supplier_email }}"
               export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ instance.vars.supplier_password }}"
               export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ instance.vars.supplier_id }}"

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -128,28 +128,6 @@
               export DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ instance.vars.admin_framework_manager_email }}"
               export DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ instance.vars.admin_framework_manager_password }}"
 
-              export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ instance.vars.supplier_email }}"
-              export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ instance.vars.supplier_password }}"
-              export DM_PRODUCTION_SUPPLIER_USER_SUPPLIER_ID="{{ instance.vars.supplier_id }}"
-
-              export DM_PRODUCTION_BUYER_USER_EMAIL="{{ instance.vars.buyer_email }}"
-              export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ instance.vars.buyer_password }}"
-
-              export DM_PRODUCTION_ADMIN_USER_EMAIL="{{ instance.vars.admin_email }}"
-              export DM_PRODUCTION_ADMIN_USER_PASSWORD="{{ instance.vars.admin_password }}"
-
-              export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ instance.vars.admin_ccs_category_email }}"
-              export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ instance.vars.admin_ccs_category_password }}"
-
-              export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ instance.vars.admin_ccs_sourcing_email }}"
-              export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ instance.vars.admin_ccs_sourcing_password }}"
-
-              export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ instance.vars.admin_manager_email }}"
-              export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ instance.vars.admin_manager_password }}"
-
-              export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ instance.vars.admin_framework_manager_email }}"
-              export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ instance.vars.admin_framework_manager_password }}"
-
 {% if variant == "smoulder" %}
               export DM_DOCUMENTS_BUCKET_NAME="digitalmarketplace-documents-{{ environment }}-{{ environment }}"
               export DM_NOTIFY_API_KEY="$NOTIFY_API_FUNCTIONAL_TESTS_KEY_{{ environment|upper }}"

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -84,27 +84,6 @@
           export DM_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
           export DM_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
 
-          export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
-          export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[environment].supplier_password }}"
-
-          export DM_PRODUCTION_ADMIN_USER_EMAIL="{{ smoke_test_variables[environment].admin_email }}"
-          export DM_PRODUCTION_ADMIN_USER_PASSWORD="{{ smoke_test_variables[environment].admin_password }}"
-
-          export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_category_email }}"
-          export DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_category_password }}"
-
-          export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
-          export DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
-
-          export DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
-          export DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
-
-          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
-          export DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
-
-          export DM_PRODUCTION_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
-          export DM_PRODUCTION_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
-
           set -x # restore echo
 
           curl ${DM_FRONTEND_DOMAIN}/_status
@@ -123,13 +102,6 @@
             -e DM_ADMIN_CCS_SOURCING_USER_EMAIL -e DM_ADMIN_CCS_SOURCING_USER_PASSWORD \
             -e DM_ADMIN_MANAGER_USER_EMAIL -e DM_ADMIN_MANAGER_USER_PASSWORD \
             -e DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
-            -e DM_PRODUCTION_SUPPLIER_USER_EMAIL -e DM_PRODUCTION_SUPPLIER_USER_PASSWORD \
-            -e DM_PRODUCTION_BUYER_USER_EMAIL -e DM_PRODUCTION_BUYER_USER_PASSWORD \
-            -e DM_PRODUCTION_ADMIN_USER_EMAIL -e DM_PRODUCTION_ADMIN_USER_PASSWORD \
-            -e DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL -e DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD \
-            -e DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL -e DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD \
-            -e DM_PRODUCTION_ADMIN_MANAGER_USER_EMAIL -e DM_PRODUCTION_ADMIN_MANAGER_USER_PASSWORD \
-            -e DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_PRODUCTION_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
             digitalmarketplace/backstopjs:2.1.0 $COMMAND --configPath=config.js
 
       - conditional-step:

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -63,6 +63,27 @@
 
           export DM_FRONTEND_DOMAIN="{{ app_urls[environment].www }}"
 
+          export DM_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
+          export DM_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[environment].supplier_password }}"
+
+          export DM_ADMIN_USER_EMAIL="{{ smoke_test_variables[environment].admin_email }}"
+          export DM_ADMIN_USER_PASSWORD="{{ smoke_test_variables[environment].admin_password }}"
+
+          export DM_ADMIN_CCS_CATEGORY_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_category_email }}"
+          export DM_ADMIN_CCS_CATEGORY_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_category_password }}"
+
+          export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
+          export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
+
+          export DM_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
+          export DM_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
+
+          export DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_framework_manager_email }}"
+          export DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_framework_manager_password }}"
+
+          export DM_BUYER_USER_EMAIL="{{ smoke_test_variables[environment].buyer_email }}"
+          export DM_BUYER_USER_PASSWORD="{{ smoke_test_variables[environment].buyer_password }}"
+
           export DM_PRODUCTION_SUPPLIER_USER_EMAIL="{{ smoke_test_variables[environment].supplier_email }}"
           export DM_PRODUCTION_SUPPLIER_USER_PASSWORD="{{ smoke_test_variables[environment].supplier_password }}"
 
@@ -95,6 +116,13 @@
 
           docker run --rm -v $(pwd):/src \
             -e DM_ENVIRONMENT -e DM_FRONTEND_DOMAIN \
+            -e DM_SUPPLIER_USER_EMAIL -e DM_SUPPLIER_USER_PASSWORD \
+            -e DM_BUYER_USER_EMAIL -e DM_BUYER_USER_PASSWORD \
+            -e DM_ADMIN_USER_EMAIL -e DM_ADMIN_USER_PASSWORD \
+            -e DM_ADMIN_CCS_CATEGORY_USER_EMAIL -e DM_ADMIN_CCS_CATEGORY_USER_PASSWORD \
+            -e DM_ADMIN_CCS_SOURCING_USER_EMAIL -e DM_ADMIN_CCS_SOURCING_USER_PASSWORD \
+            -e DM_ADMIN_MANAGER_USER_EMAIL -e DM_ADMIN_MANAGER_USER_PASSWORD \
+            -e DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
             -e DM_PRODUCTION_SUPPLIER_USER_EMAIL -e DM_PRODUCTION_SUPPLIER_USER_PASSWORD \
             -e DM_PRODUCTION_BUYER_USER_EMAIL -e DM_PRODUCTION_BUYER_USER_PASSWORD \
             -e DM_PRODUCTION_ADMIN_USER_EMAIL -e DM_PRODUCTION_ADMIN_USER_PASSWORD \


### PR DESCRIPTION
Don't refer to users for tests as "production users". Basically a find-replace `s/PRODUCTION_//`.

Needed due to alphagov/digitalmarketplace-functional-tests#594 and alphagov/digitalmarketplace-visual-regression#20.