### PR TITLE
CCS Data Controller user vars for functional/smoke tests

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -95,6 +95,9 @@
           export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_email }}"
           export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_sourcing_password }}"
 
+          export DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_ccs_data_controller_email }}"
+          export DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_ccs_data_controller_password }}"
+
           export DM_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[job.environment].admin_manager_email }}"
           export DM_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[job.environment].admin_manager_password }}"
 

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -122,6 +122,9 @@
               export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ instance.vars.admin_ccs_sourcing_email }}"
               export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ instance.vars.admin_ccs_sourcing_password }}"
 
+              export DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL="{{ instance.vars.admin_ccs_data_controller_email }}"
+              export DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD="{{ instance.vars.admin_ccs_data_controller_password }}"
+
               export DM_ADMIN_MANAGER_USER_EMAIL="{{ instance.vars.admin_manager_email }}"
               export DM_ADMIN_MANAGER_USER_PASSWORD="{{ instance.vars.admin_manager_password }}"
 

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -75,6 +75,9 @@
           export DM_ADMIN_CCS_SOURCING_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_sourcing_email }}"
           export DM_ADMIN_CCS_SOURCING_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_sourcing_password }}"
 
+          export DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL="{{ smoke_test_variables[environment].admin_ccs_data_controller_email }}"
+          export DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_ccs_data_controller_password }}"
+
           export DM_ADMIN_MANAGER_USER_EMAIL="{{ smoke_test_variables[environment].admin_manager_email }}"
           export DM_ADMIN_MANAGER_USER_PASSWORD="{{ smoke_test_variables[environment].admin_manager_password }}"
 
@@ -100,6 +103,7 @@
             -e DM_ADMIN_USER_EMAIL -e DM_ADMIN_USER_PASSWORD \
             -e DM_ADMIN_CCS_CATEGORY_USER_EMAIL -e DM_ADMIN_CCS_CATEGORY_USER_PASSWORD \
             -e DM_ADMIN_CCS_SOURCING_USER_EMAIL -e DM_ADMIN_CCS_SOURCING_USER_PASSWORD \
+            -e DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL -e DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD \
             -e DM_ADMIN_MANAGER_USER_EMAIL -e DM_ADMIN_MANAGER_USER_PASSWORD \
             -e DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
             digitalmarketplace/backstopjs:2.1.0 $COMMAND --configPath=config.js


### PR DESCRIPTION
Trello: https://trello.com/c/BOlmZpkr/341-functional-tests-for-ccs-data-controller-views

Jenkins vars to go with the new functional tests for the CCS Data Controller role (see https://github.com/alphagov/digitalmarketplace-functional-tests/pull/596).
