### PR TITLE
146 make db restore script and overnight index jobs use new scripts

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -101,36 +101,40 @@
                 }
               }
 
-              withEnv(["INDEX_NAME={{ search_config['services'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+              withEnv(["INDEX_NAME={{ search_config['services'].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
                 stage('Index target stage'){
-                  build job: "index-services-{{ environment }}",
+                  build job: "create-index-{{ environment }}",
                   parameters: [
-                    string(name: 'INDEX', value: "${INDEX_NAME}"),
-                    string(name: 'CREATE_WITH_MAPPING', value: "{{ search_config['services'][environment].default_mapping_name }}"),
+                    string(name: 'OBJECTS', value: "services"),
+                    string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
+                    string(name: 'FRAMEWORKS', value: "{{ search_config['services'].frameworks }}"),
+                    string(name: 'MAPPING', value: "{{ search_config['services'].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){
                   build job: "update-index-alias-{{ environment }}",
                   parameters: [
-                    string(name: 'ALIAS', value: "{{ search_config['services'][environment].default_index }}"),
+                    string(name: 'ALIAS', value: "{{ search_config['services'].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]
                 }
               }
 
-              withEnv(["INDEX_NAME={{ search_config['briefs'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+              withEnv(["INDEX_NAME={{ search_config['briefs'].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
                 stage('Index target stage'){
-                  build job: "index-briefs-{{ environment }}",
+                  build job: "create-index-{{ environment }}",
                   parameters: [
-                    string(name: 'INDEX', value: "${INDEX_NAME}"),
-                    string(name: 'CREATE_WITH_MAPPING', value: "{{ search_config['briefs'][environment].default_mapping_name }}"),
+                    string(name: 'OBJECTS', value: "briefs"),
+                    string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
+                    string(name: 'FRAMEWORKS', value: "{{ search_config['briefs'].frameworks }}"),
+                    string(name: 'MAPPING', value: "{{ search_config['briefs'].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){
                   build job: "update-index-alias-{{ environment }}",
                   parameters: [
-                    string(name: 'ALIAS', value: "{{ search_config['briefs'][environment].default_index }}"),
+                    string(name: 'ALIAS', value: "{{ search_config['briefs'].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -101,40 +101,40 @@
                 }
               }
 
-              withEnv(["INDEX_NAME={{ search_config['services'].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+              withEnv(["INDEX_NAME={{ search_config['services'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
                 stage('Index target stage'){
                   build job: "create-index-{{ environment }}",
                   parameters: [
                     string(name: 'OBJECTS', value: "services"),
                     string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
-                    string(name: 'FRAMEWORKS', value: "{{ search_config['services'].frameworks }}"),
-                    string(name: 'MAPPING', value: "{{ search_config['services'].default_mapping_name }}"),
+                    string(name: 'FRAMEWORKS', value: "{{ search_config['services'][environment].frameworks }}"),
+                    string(name: 'MAPPING', value: "{{ search_config['services'][environment].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){
                   build job: "update-index-alias-{{ environment }}",
                   parameters: [
-                    string(name: 'ALIAS', value: "{{ search_config['services'].default_index }}"),
+                    string(name: 'ALIAS', value: "{{ search_config['services'][environment].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]
                 }
               }
 
-              withEnv(["INDEX_NAME={{ search_config['briefs'].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
+              withEnv(["INDEX_NAME={{ search_config['briefs'][environment].default_index }}-${new java.text.SimpleDateFormat('yyyy-MM-dd').format(new Date())}"]){
                 stage('Index target stage'){
                   build job: "create-index-{{ environment }}",
                   parameters: [
                     string(name: 'OBJECTS', value: "briefs"),
                     string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
-                    string(name: 'FRAMEWORKS', value: "{{ search_config['briefs'].frameworks }}"),
-                    string(name: 'MAPPING', value: "{{ search_config['briefs'].default_mapping_name }}"),
+                    string(name: 'FRAMEWORKS', value: "{{ search_config['briefs'][environment].frameworks }}"),
+                    string(name: 'MAPPING', value: "{{ search_config['briefs'][environment].default_mapping_name }}"),
                   ]
                 }
                 stage('Update index alias'){
                   build job: "update-index-alias-{{ environment }}",
                   parameters: [
-                    string(name: 'ALIAS', value: "{{ search_config['briefs'].default_index }}"),
+                    string(name: 'ALIAS', value: "{{ search_config['briefs'][environment].default_index }}"),
                     string(name: 'TARGET', value: "${INDEX_NAME}"),
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -25,4 +25,7 @@
             OBJECTS=briefs
             INDEX={{ search_config['briefs'].default_index }}
             FRAMEWORKS={{ search_config['briefs'].frameworks }}
+
+      - shell: |
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="{{ search_config['briefs'].default_index }}" --frameworks="{{ search_config['briefs'].frameworks }}"
 {% endfor %}

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -2,27 +2,34 @@
 - job:
     name: "update-briefs-index-{{ environment }}"
     display-name: "Index briefs - {{ environment }}"
-    project-type: freestyle
+    project-type: pipeline
     description: "Update the {{ environment }} briefs index with briefs in the {{ environment }} database."
+    concurrent: false
     triggers:
       - timed: "H 3 * * *"
-    publishers:
-      - trigger-parameterized-builds:
-          - project: notify-slack
-            condition: UNSTABLE_OR_WORSE
-            predefined-parameters: |
-              USERNAME=index-briefs
-              JOB=Index briefs {{ environment }} :jenkins_parrot:
-              ICON=:alarm_clock:
-              STAGE={{ environment }}
-              STATUS=FAILED
-              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
-    builders:
-      - trigger-builds:
-        - project: update-index-{{ environment }}
-          predefined-parameters: |
-            OBJECTS=briefs
-            INDEX={{ search_config['briefs'].default_index }}
-            FRAMEWORKS={{ search_config['briefs'].frameworks }}
+    dsl: |
+        node {
+          try {
+            stage('Update index') {
+              build job: "update-index-{{ environment }}",
+              parameters: [
+                string(name: 'OBJECTS', value: "briefs"),
+                string(name: 'INDEX', value: "{{ search_config['briefs'][environment].default_index }}"),
+                string(name: 'FRAMEWORKS', value: "{{ search_config['briefs'][environment].frameworks }}")
+              ]
+            }
+          } catch(err) {
+            currentBuild.result = 'FAILURE'
+            echo "Error: ${err}"
+            build job: 'notify-slack', parameters: [
+              string(name: 'USERNAME', value: "index-briefs"),
+              string(name: 'JOB', value: "Index briefs {{ environment }} :jenkins_parrot:"),
+              string(name: 'ICON', value: ":alarm_clock:"),
+              string(name: 'STAGE', value: "{{ environment }}"),
+              string(name: 'STATUS', value: "FAILED"),
+              string(name: 'URL', value: "<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>"),
+              string(name: 'CHANNEL', value: "#dm-release")
+            ]
+          }
+        }
 {% endfor %}

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -25,7 +25,4 @@
             OBJECTS=briefs
             INDEX={{ search_config['briefs'].default_index }}
             FRAMEWORKS={{ search_config['briefs'].frameworks }}
-
-      - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="{{ search_config['briefs'].default_index }}" --frameworks="{{ search_config['briefs'].frameworks }}"
 {% endfor %}

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -3,25 +3,7 @@
     name: "index-briefs-{{ environment }}"
     display-name: "Index briefs - {{ environment }}"
     project-type: freestyle
-    description: "This imports all briefs (opportunities) in the current API database into the current Elasticsearch index."
-    parameters:
-      - string:
-          name: INDEX
-          default: {{ search_config['briefs'][environment].default_index }}
-          description: "Index name or alias to use (eg 'briefs-digital-outcomes-and-specialists')"
-      - string:
-          name: FRAMEWORKS
-          default: {{ search_config['briefs'][environment].frameworks }}
-          description: >
-            Comma-separated list of framework slugs that should be indexed
-            (eg 'digital-outcomes-and-specialists,digital-outcomes-and-specialists-2').
-      - string:
-          name: CREATE_WITH_MAPPING
-          description: >
-            Create the named index using mapping <mapping>. There's no default here, as
-            creating indexes should be done under user control on the Production environment.
-            This mapping is a filename (without .json suffix) as would be found by the
-            search-api in its digitalmarketplace-search-api/mappings directory.
+    description: "Update the {{ environment }} briefs index with briefs in the {{ environment }} database."
     triggers:
       - timed: "H 3 * * *"
     publishers:
@@ -38,5 +20,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="{{ search_config['briefs'].default_index }}" --frameworks="{{ search_config['briefs'].frameworks }}"
 {% endfor %}

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -1,6 +1,6 @@
 {% for environment in ['preview', 'staging', 'production'] %}
 - job:
-    name: "index-briefs-{{ environment }}"
+    name: "update-briefs-index-{{ environment }}"
     display-name: "Index briefs - {{ environment }}"
     project-type: freestyle
     description: "Update the {{ environment }} briefs index with briefs in the {{ environment }} database."
@@ -19,6 +19,10 @@
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-release
     builders:
-      - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py briefs '{{ environment }}' --serial --index="{{ search_config['briefs'].default_index }}" --frameworks="{{ search_config['briefs'].frameworks }}"
+      - trigger-builds:
+        - project: update-index-{{ environment }}
+          predefined-parameters: |
+            OBJECTS=briefs
+            INDEX={{ search_config['briefs'].default_index }}
+            FRAMEWORKS={{ search_config['briefs'].frameworks }}
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -2,27 +2,34 @@
 - job:
     name: "update-services-index-{{ environment }}"
     display-name: "Index services - {{ environment }}"
-    project-type: freestyle
+    project-type: pipeline
     description: "Update the {{ environment }} services index with services in the {{ environment }} database."
+    concurrent: false
     triggers:
       - timed: "H 2 * * *"
-    publishers:
-      - trigger-parameterized-builds:
-          - project: notify-slack
-            condition: UNSTABLE_OR_WORSE
-            predefined-parameters: |
-              USERNAME=index-services
-              JOB=Index services {{ environment }} :jenkins_parrot:
-              ICON=:alarm_clock:
-              STAGE={{ environment }}
-              STATUS=FAILED
-              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
-    builders:
-      - trigger-builds:
-        - project: update-index-{{ environment }}
-          predefined-parameters: |
-            OBJECTS=services
-            INDEX={{ search_config['services'].default_index }}
-            FRAMEWORKS={{ search_config['services'].frameworks }}
+    dsl: |
+        node {
+          try {
+            stage('Update index') {
+              build job: "update-index-{{ environment }}",
+              parameters: [
+                string(name: 'OBJECTS', value: "services"),
+                string(name: 'INDEX', value: "{{ search_config['services'][environment].default_index }}"),
+                string(name: 'FRAMEWORKS', value: "{{ search_config['services'][environment].frameworks }}")
+              ]
+            }
+          } catch(err) {
+            currentBuild.result = 'FAILURE'
+            echo "Error: ${err}"
+            build job: 'notify-slack', parameters: [
+              string(name: 'USERNAME', value: "index-services"),
+              string(name: 'JOB', value: "Index services {{ environment }} :jenkins_parrot:"),
+              string(name: 'ICON', value: ":alarm_clock:"),
+              string(name: 'STAGE', value: "{{ environment }}"),
+              string(name: 'STATUS', value: "FAILED"),
+              string(name: 'URL', value: "<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>"),
+              string(name: 'CHANNEL', value: "#dm-2ndline")
+            ]
+          }
+        }
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -1,6 +1,6 @@
 {% for environment in ['preview', 'staging', 'production'] %}
 - job:
-    name: "index-services-{{ environment }}"
+    name: "update-services-index-{{ environment }}"
     display-name: "Index services - {{ environment }}"
     project-type: freestyle
     description: "Update the {{ environment }} services index with services in the {{ environment }} database."
@@ -19,6 +19,10 @@
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-release
     builders:
-      - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="{{ search_config['services'].default_index }}" --frameworks="{{ search_config['services'].frameworks }}"
+      - trigger-builds:
+        - project: update-index-{{ environment }}
+          predefined-parameters: |
+            OBJECTS=services
+            INDEX={{ search_config['services'].default_index }}
+            FRAMEWORKS={{ search_config['services'].frameworks }}
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -25,6 +25,4 @@
             OBJECTS=services
             INDEX={{ search_config['services'].default_index }}
             FRAMEWORKS={{ search_config['services'].frameworks }}
-      - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="{{ search_config['services'].default_index }}" --frameworks="{{ search_config['services'].frameworks }}"
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -25,4 +25,6 @@
             OBJECTS=services
             INDEX={{ search_config['services'].default_index }}
             FRAMEWORKS={{ search_config['services'].frameworks }}
+      - shell: |
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="{{ search_config['services'].default_index }}" --frameworks="{{ search_config['services'].frameworks }}"
 {% endfor %}

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -3,23 +3,7 @@
     name: "index-services-{{ environment }}"
     display-name: "Index services - {{ environment }}"
     project-type: freestyle
-    description: "This imports all services in the current API database into the current Elasticsearch index."
-    parameters:
-      - string:
-          name: INDEX
-          default: {{ search_config['services'][environment].default_index }}
-          description: "Index name or alias to use (eg 'g-cloud-9-2017-05-22')"
-      - string:
-          name: FRAMEWORKS
-          default: {{ search_config['services'][environment].frameworks }}
-          description: "Comma-separated list of framework slugs that should be indexed (eg 'g-cloud-7,g-cloud-8'). If no frameworks are specified then all currently published services will be indexed."
-      - string:
-          name: CREATE_WITH_MAPPING
-          description: >
-            Create the named index using mapping <mapping>. There's no default here, as
-            creating indexes should be done under user control on the Production environment.
-            This mapping is a filename (without .json suffix) as would be found by the
-            search-api in its digitalmarketplace-search-api/mappings directory.
+    description: "Update the {{ environment }} services index with services in the {{ environment }} database."
     triggers:
       - timed: "H 2 * * *"
     publishers:
@@ -36,5 +20,5 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="${INDEX}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${CREATE_WITH_MAPPING}"
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py services '{{ environment }}' --serial --index="{{ search_config['services'].default_index }}" --frameworks="{{ search_config['services'].frameworks }}"
 {% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -213,4 +213,4 @@ search_config:
   services:
     default_index: g-cloud-10
     frameworks: g-cloud-10
-    default_mapping_name: services
+    default_mapping_name: services-g-cloud-10

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -112,15 +112,23 @@ jenkins_list_views:
       - export-supplier-csv-preview
       - export-supplier-csv-staging
       - export-supplier-csv-production
-      - index-services-preview
-      - index-services-staging
-      - index-services-production
-      - index-briefs-preview
-      - index-briefs-staging
-      - index-briefs-production
+  - name: "ES indexes"
+    jobs:
+      - create-index-preview
+      - create-index-staging
+      - create-index-production
+      - update-index-preview
+      - update-index-staging
+      - update-index-production
       - update-index-alias-preview
       - update-index-alias-staging
       - update-index-alias-production
+      - update-briefs-index-preview
+      - update-briefs-index-staging
+      - update-briefs-index-production
+      - update-services-index-preview
+      - update-services-index-staging
+      - update-services-index-production
   - name: "Functional, visual, and smoke tests"
     jobs:
       - apps-are-up-preview

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -213,4 +213,5 @@ search_config:
   services:
     default_index: g-cloud-10
     frameworks: g-cloud-10
-    default_mapping_name: services-g-cloud-10
+    default_mapping_name: services
+

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -213,5 +213,4 @@ search_config:
   services:
     default_index: g-cloud-10
     frameworks: g-cloud-10
-    default_mapping_name: services
-
+    default_mapping_name: services-g-cloud-10

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -207,10 +207,28 @@ app_urls:
 
 search_config:
   briefs:
-    default_index: briefs-digital-outcomes-and-specialists
-    frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
-    default_mapping_name: briefs-digital-outcomes-and-specialists-2
+    preview:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
+    staging:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
+    production:
+      default_index: briefs-digital-outcomes-and-specialists
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
-    default_index: g-cloud-10
-    frameworks: g-cloud-10
-    default_mapping_name: services-g-cloud-10
+    preview:
+      default_index: g-cloud-10
+      frameworks: g-cloud-10
+      default_mapping_name: services-g-cloud-10
+    staging:
+      default_index: g-cloud-10
+      frameworks: g-cloud-10
+      default_mapping_name: services-g-cloud-10
+    production:
+      default_index: g-cloud-10
+      frameworks: g-cloud-10
+      default_mapping_name: services-g-cloud-10

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -207,28 +207,10 @@ app_urls:
 
 search_config:
   briefs:
-    preview:
-      default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
-      default_mapping_name: briefs-digital-outcomes-and-specialists-2
-    staging:
-      default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
-      default_mapping_name: briefs-digital-outcomes-and-specialists-2
-    production:
-      default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
-      default_mapping_name: briefs-digital-outcomes-and-specialists-2
+    default_index: briefs-digital-outcomes-and-specialists
+    frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+    default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
-    preview:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
-    staging:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
-    production:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
+    default_index: g-cloud-10
+    frameworks: g-cloud-10
+    default_mapping_name: services


### PR DESCRIPTION
Blocks 
https://trello.com/c/JHNsajHC/393-remove-extra-service-index-job


What this pr does is rename
https://ci.marketplace.team/job/index-services-preview/
https://ci.marketplace.team/job/index-services-staging/
https://ci.marketplace.team/job/index-services-production/
https://ci.marketplace.team/job/index-briefs-preview/
https://ci.marketplace.team/job/index-briefs-staging/
https://ci.marketplace.team/job/index-briefs-production/
to
https://ci.marketplace.team/job/update-services-index-preview/
https://ci.marketplace.team/job/update-services-index-staging/
https://ci.marketplace.team/job/update-services-index-production/
https://ci.marketplace.team/job/update-briefs-index-preview/
https://ci.marketplace.team/job/update-briefs-index-staging/
https://ci.marketplace.team/job/update-briefs-index-production/

move them to be pipelines and to use the new `update-index` job instead of running the `scripts/index-to-search-service.py` script directly.
Those are all catch up jobs basically, that reindex everything over night to make sure all changes are propagated.

We'll have to remove the old ones manually once it's done.

It also uses the new create-index jobs when doing the db refreshes.