### PR TITLE
Add 'nextexecutions' plugin to plugin list

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -67,6 +67,7 @@ jenkins_plugins:
   - greenballs
   - htmlpublisher
   - lockable-resources
+  - nextexecutions
   - nodejs
   - parameterized-trigger
   - postbuildscript


### PR DESCRIPTION
We want to try out the nextexecutions plugin

https://trello.com/c/IxC4VJRt/716-can-we-have-this-thing-https-pluginsjenkinsio-next-executions
![next-executions_column jpeg](https://user-images.githubusercontent.com/3469840/53740738-c4d2be80-3e8c-11e9-848d-9e7c80b1ddc7.jpg)
