### PR TITLE
405-gdrive-client-alternatives-db-dumps-to-s3-not-drive

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -1,11 +1,11 @@
-{% set environments = ['google-drive', 'preview', 'staging'] %}
+{% set environments = ['s3', 'preview', 'staging'] %}
 ---
 {% for environment in environments %}
 - job:
     name: "clean-and-apply-db-dump-{{ environment }}"
     display-name: "Clean and apply database dump - {{ environment }}"
     project-type: pipeline
-    description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also Google Drive."
+    description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also S3."
     concurrent: false
 {% if environment == 'staging' %}
     triggers:
@@ -77,12 +77,9 @@
                 )
               }
 
-              stage('Apply data to target stage and google drive') {
+              stage('Apply data to target stage and s3') {
                 sh(
                    script: '''
-                     set +x
-                     export GDRIVE_EXPORTDATA_FOLDER_ID="{{ jenkins_gdrive_db_dumps_folder_id }}"
-                     set -x
                      export TARGET="{{ environment }}"
                      make apply-cleaned-db-dump
                    '''

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -104,7 +104,7 @@ build_monitor_jobs:
 jenkins_list_views:
   - name: "Data"
     jobs:
-      - clean-and-apply-db-dump-google-drive
+      - clean-and-apply-db-dump-s3
       - clean-and-apply-db-dump-preview
       - clean-and-apply-db-dump-staging
       - database-backup


### PR DESCRIPTION
Update clean_and_apply_db_dump.yml to provide s3 argument

https://trello.com/c/0jAgMP0d/405-gdrive-client-alternatives-db-dumps-to-s3-not-drive

Requires:
https://github.com/alphagov/digitalmarketplace-aws/pull/509

Change upload to go to s3
