### PR TITLE
Update jobs to alert in 2nd line if not a release or staging/ preview job

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -19,7 +19,7 @@
           string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "{{ environment }}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/data_retention.yml
+++ b/job_definitions/data_retention.yml
@@ -24,7 +24,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -20,7 +20,7 @@
                 string(name: 'USERNAME', value: "database-backup"),
                 string(name: 'ICON', value: icon),
                 string(name: 'JOB', value: "Backup ${STAGE} database to S3"),
-                string(name: 'CHANNEL', value: "#dm-release"),
+                string(name: 'CHANNEL', value: "#dm-2ndline"),
                 text(name: 'STAGE', value: "${STAGE}"),
                 text(name: 'STATUS', value: status),
                 text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -19,7 +19,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2nd-line
     builders:
       - shell: |
 

--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -23,7 +23,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
 

--- a/job_definitions/index_briefs.yml
+++ b/job_definitions/index_briefs.yml
@@ -28,7 +28,7 @@
               string(name: 'STAGE', value: "{{ environment }}"),
               string(name: 'STATUS', value: "FAILED"),
               string(name: 'URL', value: "<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>"),
-              string(name: 'CHANNEL', value: "#dm-release")
+              string(name: 'CHANNEL', value: "#dm-2ndline")
             ]
           }
         }

--- a/job_definitions/notify_buyers_to_award_closed_briefs.yml
+++ b/job_definitions/notify_buyers_to_award_closed_briefs.yml
@@ -51,7 +51,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ -n "$OFFSET_DAYS" ]; then

--- a/job_definitions/notify_buyers_when_requirements_close.yml
+++ b/job_definitions/notify_buyers_when_requirements_close.yml
@@ -34,7 +34,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ -n "$DATE_CLOSED" ]; then

--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -33,7 +33,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ -n "$AWARDED_AT" ]; then

--- a/job_definitions/notify_suppliers_of_brief_withdrawals.yml
+++ b/job_definitions/notify_suppliers_of_brief_withdrawals.yml
@@ -33,7 +33,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
 

--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -51,7 +51,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$MAILCHIMP_LIST_ID" = "test-list" ]; then

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -34,7 +34,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ -n "$SUPPLIER_IDS" ]; then

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -48,7 +48,7 @@
       - ansicolor
     dsl: |
 
-      def notify_slack(icon, status) {
+      def notify_slack(icon, status, channel = "#dm-release") {
         build job: "notify-slack",
               parameters: [
                 string(name: 'USERNAME', value: '{{ test_type.slack_username }}'),
@@ -127,7 +127,7 @@
           }
         } catch(err) {
         {% if environment == 'production' %}
-          notify_slack(':fire:', 'FAILED')
+          notify_slack(':fire:', 'FAILED', "#dm-2ndline")
         {% else %}
           try {
             def migrations_being_run = sh(

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -26,7 +26,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/snapshot-framework-stats.py "{{ framework }}" "{{ environment }}"

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -28,7 +28,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_tokens[pp_service] }} {{ pp_service }} --{{ period }}

--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -26,7 +26,7 @@
               STAGE=production
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           docker run -e DM_DATA_API_TOKEN_PRODUCTION digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }}


### PR DESCRIPTION
Updated jobs based on the spreadsheet here:
https://docs.google.com/spreadsheets/d/1ON-BSxAubcGQ2OtdWFxNIcXX2keMkAB1N6_gg-LeuUA/edit#gid=376691177

Job, desc, action, trigger
![Screen Shot 2019-03-11 at 12 11 35](https://user-images.githubusercontent.com/3469840/54123167-e84eb980-43f6-11e9-825e-3a2098d49f56.png)



Basically, if a job is triggered by a dev or a release or if it runs tests that are exclusively run on staging/ preview it should report in #dm-release. Otherwise if it is a timed job run against prod it should notify in #dm-2ndline.


https://trello.com/c/TWjw81OW/382-script-failures-and-prod-smoke-test-failures-should-report-in-2nd-line