### PR TITLE
Move stats jobs into framework lifecycle tab

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -1,5 +1,5 @@
-{% set environments = ['preview'] %}
-{% set frameworks = [('g-cloud-11', 'true')] %}
+{% set environments = ['production'] %}
+{% set frameworks = [('g-cloud-11', 'false')] %}
 ---
 {% for environment in environments %}
 {% for framework, disabled in frameworks %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,5 +1,5 @@
-{% set environments = ['preview'] %}
-{% set frameworks = [('g-cloud-11', 'g-cloud', 'true')] %}
+{% set environments = ['production] %}
+{% set frameworks = [('g-cloud-11', 'gcloud', 'false')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -193,6 +193,13 @@ jenkins_list_views:
       - publish-g-cloud-draft-services-preview
       - publish-g-cloud-draft-services-staging
       - publish-g-cloud-draft-services-production
+      - performance-platform-stats-g-cloud-11-per-hour-preview
+      - performance-platform-stats-g-cloud-11-per-day-preview
+      - performance-platform-stats-g-cloud-11-per-hour-production
+      - performance-platform-stats-g-cloud-11-per-day-production
+      - snapshot-stats-g-cloud-11-preview
+      - snapshot-stats-g-cloud-11-production
+
 
 app_urls:
   preview:


### PR DESCRIPTION
Trello: https://trello.com/c/gwWOnyIm/430-create-g-11-data-dashboard

~Not ready for merging yet (wait until preview versions have been tested).~

- Creates the production versions of the stats jobs
- Moves the stats jobs into the Framework Lifecycle tab on the dashboard for easy finding 