### PR TITLE
Disable export data job for now

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -1,10 +1,12 @@
 {% set environments = ['preview', 'production'] %}
+{% set disabled = 'true' %}
 ---
 {% for environment in environments %}
 - job:
     name: "export-data-{{ environment }}"
     display-name: "Export API model data as CSV - {{ environment }}"
     project-type: freestyle
+    disabled: {{ disabled }}
     description: "Runs the get-model-data.py script and uploads the generated CSV files to Google Drive (everything, for us) and S3 (just the opportunity data, for the public)"
     triggers:
       - timed: "H 5 * * *"


### PR DESCRIPTION
Related to https://trello.com/c/uUxYtjSt/657-gdrive-client-alternatives-consolidate-data-dumps-exports.

The job keeps failing anyway, let's disable it for now.