### PR TITLE
Fix token key in performance platformm job

### DIFF
--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,9 +1,9 @@
-{% set environments = ['production] %}
-{% set frameworks = [('g-cloud-11', 'gcloud', 'false')] %}
+{% set environments = ['production'] %}
+{% set frameworks = [('g-cloud-11', 'gcloud', 'g-cloud', 'false')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}
-{% for framework, pp_service, disabled in frameworks %}
+{% for framework, pp_service, token_group, disabled in frameworks %}
 {% for schedule, period in schedules %}
 - job:
     name: 'performance-platform-stats-{{ framework }}-per-{{ period }}-{{ environment }}'
@@ -31,7 +31,7 @@
               CHANNEL=#dm-2ndline
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_tokens[pp_service] }} {{ pp_service }} --{{ period }}
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_tokens[token_group] }} {{ pp_service }} --{{ period }}
 
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Trello: https://trello.com/c/gwWOnyIm/430-create-g-11-data-dashboard

Two tiny fixes:
- Missing quote around `'production`
- The performance platform has fixed our url as `gcloud` (i.e. without the dash) so we still need this otherwise-wrong string for the script. However our credentials store the performance platform token under the key `g-cloud` (which is as it should be), so we should use that to look up the creds.

The jobs have already been refreshed with this branch on Jenkins.