### PR TITLE
Add G11 to supplier export job

### DIFF
--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -1,6 +1,6 @@
 {% set environments = ['preview', 'staging', 'production'] %}
 {% set frameworks = [
-    'g-cloud-9', 'g-cloud-10', 'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'
+    'g-cloud-9', 'g-cloud-10', 'g-cloud-11', 'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'
   ]
 %}
 ---


### PR DESCRIPTION
This job creates CSV exports of the supplier details, which is needed by the framework manager admin to contact suppliers about clarification questions etc.

I've already run this for the production stage to generate the first set of reports.