### PR TITLE
Reenable exporting data

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -1,12 +1,10 @@
 {% set environments = ['preview', 'production'] %}
-{% set disabled = 'true' %}
 ---
 {% for environment in environments %}
 - job:
     name: "export-data-{{ environment }}"
     display-name: "Export API model data as CSV - {{ environment }}"
     project-type: freestyle
-    disabled: {{ disabled }}
     description: "Runs the get-model-data.py script and uploads the generated CSV files to Google Drive (everything, for us) and S3 (just the opportunity data, for the public)"
     triggers:
       - timed: "H 5 * * *"


### PR DESCRIPTION
We've given the gdrive api a bit of a rest, and we've also stopped uploading large files, so let's reenable the data export and see whether the limit is still breached constantly.