### PR TITLE
Remove performance platform token from Jenkins job config

### DIFF
--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,9 +1,9 @@
 {% set environments = ['production'] %}
-{% set frameworks = [('g-cloud-11', 'gcloud', 'g-cloud', 'false')] %}
+{% set frameworks = [('g-cloud-11', 'gcloud', 'false')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}
-{% for framework, pp_service, token_group, disabled in frameworks %}
+{% for framework, pp_service, disabled in frameworks %}
 {% for schedule, period in schedules %}
 - job:
     name: 'performance-platform-stats-{{ framework }}-per-{{ period }}-{{ environment }}'
@@ -31,7 +31,7 @@
               CHANNEL=#dm-2ndline
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ performance_platform_bearer_tokens[token_group] }} {{ pp_service }} --{{ period }}
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ pp_service }} --{{ period }}
 
 {% endfor %}
 {% endfor %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -31,7 +31,7 @@
               CHANNEL=#dm-2ndline
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ pp_service }} --{{ period }}
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/framework-applications/send-stats-to-performance-platform.py {{ framework }} {{ environment }} {{ pp_service }} --{{ period }}
 
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Trello: https://trello.com/c/TZoo1F5B/480-performance-platform-jenkins-job-leaks-token

The token is now retrieved from credentials by the script itself. See https://github.com/alphagov/digitalmarketplace-scripts/pull/374