### PR TITLE
build docker image job: add options HEAD_BRANCH and MARK_LATEST

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -42,6 +42,12 @@
               }
 
               stage('Prepare') {
+                  if (RELEASE_NAME ==~ /release-\d+/ && HEAD_BRANCH != "master") {
+                    input("WARNING: It is probably a bad idea to create a release- tagged image from a non-master HEAD_BRANCH!")
+                  }
+                  if (MARK_LATEST.toString() == "true" && HEAD_BRANCH != "master") {
+                    input("WARNING: It is probably a bad idea to mark a non-master HEAD_BRANCH image as 'latest'")
+                  }
                   git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: HEAD_BRANCH, credentialsId: 'github_com_and_enterprise'
                   echo "Cleaning repository"
                   sh("git clean -fdx")

--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -14,11 +14,19 @@
             - scripts
       - string:
           name: RELEASE_NAME
-          description: "Application tag (eg 'release-42') to checkout for building the artefact"
+          description: "git ref (eg 'release-42') to checkout for building the artefact. This will also become the image release name."
       - bool:
           name: REBUILD
           default: false
           description: "Rerun the build even if the release already exists"
+      - string:
+          name: HEAD_BRANCH
+          default: "master"
+          description: "RELEASE_NAME must be present in this branch. *USE WITH CARE* - production releases should *ALWAYS* be present in master"
+      - bool:
+          name: MARK_LATEST
+          default: true
+          description: "Whether to mark the built image as the application's 'latest'"
     dsl: |
       node {
           try {
@@ -34,7 +42,7 @@
               }
 
               stage('Prepare') {
-                  git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: 'master', credentialsId: 'github_com_and_enterprise'
+                  git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git", branch: HEAD_BRANCH, credentialsId: 'github_com_and_enterprise'
                   echo "Cleaning repository"
                   sh("git clean -fdx")
                   echo "Checking out ${RELEASE_NAME}"
@@ -51,7 +59,9 @@
                   }
 
                   sh("docker push digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
-                  sh("docker push digitalmarketplace/${REPOSITORY}:latest")
+                  if (MARK_LATEST.toString() == "true") {
+                    sh("docker push digitalmarketplace/${REPOSITORY}:latest")
+                  }
               }
           } catch(err) {
               currentBuild.result = 'FAILURE'


### PR DESCRIPTION
In the lead up to investigating https://trello.com/c/skD666lL

These should allow the job to build experimental off-branch images without interfering with the regular release pipeline. Right?

What do people think? I don't know what I'm doing.