### PR TITLE
Use official BackstopJS Docker image for visual regression tests

### DIFF
--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -96,7 +96,9 @@
           curl ${DM_FRONTEND_DOMAIN}/admin/_status
           curl ${DM_FRONTEND_DOMAIN}/user/_status
 
-          docker run --rm -v $(pwd):/src \
+          BACKSTOP_VERSION="$(jq -r '.dependencies.backstopjs.version' package-lock.json)"
+
+          docker run --pull --rm -v $(pwd):/src \
             -e DM_ENVIRONMENT -e DM_FRONTEND_DOMAIN \
             -e DM_SUPPLIER_USER_EMAIL -e DM_SUPPLIER_USER_PASSWORD \
             -e DM_BUYER_USER_EMAIL -e DM_BUYER_USER_PASSWORD \
@@ -106,7 +108,7 @@
             -e DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL -e DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD \
             -e DM_ADMIN_MANAGER_USER_EMAIL -e DM_ADMIN_MANAGER_USER_PASSWORD \
             -e DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL -e DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD \
-            digitalmarketplace/backstopjs:2.1.0 $COMMAND --configPath=config.js
+            backstopjs/backstopjs:$BACKSTOP_VERSION $COMMAND --configPath=config.js
 
       - conditional-step:
           condition-kind: and

--- a/playbooks/roles/jenkins/tasks/tools.yml
+++ b/playbooks/roles/jenkins/tasks/tools.yml
@@ -112,22 +112,6 @@
   tags: [apt]
   apt: pkg=nodejs=4.* state=present
 
-# TODO: Stop installing PhantomJS like this when there is a better
-#       apt source available.
-- name: Download PhantomJS
-  get_url:
-    url: "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
-    dest: /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2
-
-- name: Unarchive PhantomJS
-  unarchive:
-    src: /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2
-    dest: /usr/local/src
-    copy: no
-
-- name: Install PhantomJS binary
-  file: src=/usr/local/src/phantomjs-2.1.1-linux-x86_64/bin/phantomjs dest=/usr/local/bin/phantomjs state=link
-
 - name: Give jenkins user permissions on its home directory
   file:
     path: /var/lib/jenkins


### PR DESCRIPTION
Ticket: https://trello.com/c/NfXVasgY/493-vr-repo-docker-image

Once https://github.com/alphagov/digitalmarketplace-visual-regression/pull/24 has been merged we can replace our custom Docker image with the [official BackstopJS one](https://hub.docker.com/r/backstopjs/backstopjs), and all will be right with the world.

This PR makes the change to the Jenkins job, and removes PhantomJS from the playbook.

PhantomJS will remain installed on Jenkins, but we can remove it manually if we wish.