### PR TITLE
Pass DUMP_FILE_NAME as parameter to backup task

### DIFF
--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -52,7 +52,7 @@
               sh('''
                 pyenv local 3.6.2
                 make requirements
-                DUMP_FILE_NAME=${DUMP_FILE_NAME} make ${STAGE} deploy-db-backup-app
+                make ${STAGE} deploy-db-backup-app DUMP_FILE_NAME=${DUMP_FILE_NAME}
               ''')
               timeout(10) {
                 waitUntil {


### PR DESCRIPTION
Trello: https://trello.com/c/f1PbVXEW/785-db-backup-app-runs-out-of-memory

Discovered during the DB backup failures.

Previously the task was setting its own value for `DUMP_FILE_NAME` - 1 second later, according to the timestamp - which was conflicting with the Jenkins `DUMP_FILE_NAME`, and causing the decryption check step to fail.

See changes to the Makefile task: https://github.com/alphagov/digitalmarketplace-aws/pull/555