### PR TITLE
Add job to validate CloudTrail logs periodically

### DIFF
--- a/job_definitions/validate_cloudtrail_logs.yml
+++ b/job_definitions/validate_cloudtrail_logs.yml
@@ -1,0 +1,92 @@
+---
+- job:
+    name: validate-cloudtrail-logs
+    project-type: freestyle
+    display-name: Validate logs stored by Amazon CloudWatch in S3.
+    parameters:
+      - choice:
+          name: ACCOUNT
+          choices:
+            - main
+            - development
+            - production
+            - backups
+      - string:
+          name: START_FROM
+          default: "3 days ago"
+          description: Logs delivered on or after the specified time will be validated. Can be in any format accepted by GNU date.
+      - string:
+          name: UP_TO
+          default: "now"
+          description: Logs delivered on or before the specified time will be validated. Can be in any format accepted by GNU date.
+      - bool:
+          name: VERBOSE
+          default: false
+          description: Print verbose log validation information.
+    builders:
+      - shell: |
+          docker run --rm \
+            -v /var/lib/jenkins/digitalmarketplace-credentials:/digitalmarketplace-credentials \
+            -e DM_CREDENTIALS_REPO=/digitalmarketplace-credentials \
+            -e VERBOSE=$VERBOSE \
+            digitalmarketplace/scripts \
+            scripts/validate-cloudtrail-logs.sh $ACCOUNT $START_FROM $UP_TO
+
+- job:
+    name: validate-cloudtrail-logs-periodic
+    project-type: pipeline
+    display-name: Validate the last 3 days of logs every hour or so.
+    triggers:
+      - timed: '@hourly'
+    dsl: |
+
+      def notify_slack(accounts, status) {
+        build job: "notify-slack",
+        parameters: [
+          string(name: 'USERNAME', value: "validate-cloudtrail-logs"),
+          string(name: 'ICON', value: ":red_circle:"),
+          string(name: 'JOB', value: "Validating CloudTrail logs in ${accounts.join(', ')} account ${status}"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
+          text(name: 'STATUS', value: status),
+          text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+        ]
+      }
+
+      failed_accounts = []
+
+      def do_validate(account) {
+        try {
+          build job: "validate-cloudtrail-logs"
+          parameters: [
+            string(name: "ACCOUNT", value: account),
+            string(name: "START_FROM", value: "3 days ago"),
+            string(name: "UP_TO", value: "now"),
+          ]
+        } catch(err) {
+          failed_accounts << account
+          currentBuild.result = 'FAILURE'
+        }
+      }
+
+      node {
+        stage('main') {
+          do_validate("main")
+        }
+
+        stage('development') {
+          do_validate("development")
+        }
+
+        stage('production') {
+          do_validate("production")
+        }
+
+        stage('backups') {
+          do_validate("backups")
+        }
+
+        if ( currentBuild.result == 'FAILURE' ) {
+          notify_slack(failed_accounts, 'FAILED')
+        }
+      }
+

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -39,6 +39,28 @@
     name: awscli==1.16.109
     state: present
 
+- name: Create AWS cli config folder
+  file:
+    path: ~/.aws
+    state: directory
+    owner: jenkins
+    group: jenkins
+    mode: u=rwx
+  become: true
+  become_user: jenkins
+
+- name: Create AWS cli config file
+  template:
+    src: aws_config.j2
+    dest: ~/.aws/config
+    owner: jenkins
+    group: jenkins
+    mode: u=rw
+  become: true
+  become_user: jenkins
+  vars:
+    assume_roles: "{{ cloudtrail_validate_logs_roles }}"
+
 - name: Install rbenv and pyenv
   git: repo={{ item.repo }} dest=/var/lib/jenkins/{{ item.path }}
   with_items:

--- a/playbooks/roles/jenkins/templates/aws_config.j2
+++ b/playbooks/roles/jenkins/templates/aws_config.j2
@@ -1,0 +1,7 @@
+{% for role in assume_roles %}
+
+[profile {{role.profile.name}}]
+credentials_source=Ec2InstanceMetadata
+region={{role.profile.region}}
+role_arn={{role.profile.role_arn}}
+{% endfor %}


### PR DESCRIPTION
Implements https://trello.com/c/Ijzuk0qY/508-log-file-validation-job, needs https://github.com/alphagov/digitalmarketplace-credentials/pull/221 and https://github.com/alphagov/digitalmarketplace-scripts/pull/387 to be merged to work.

This PR creates a job that will hourly test the last three days of CloudTrail logs for each of our four AWS accounts. This schedule was suggested by @agalmatis but isn't fixed in stone.

The job relies on being able to assume the `cloudtrail-validate-logs` role created in https://github.com/alphagov/digitalmarketplace-aws/pull/572. The way that this has been achieved is by using the fact that Jenkins runs on AWS EC2; this PR adds a config file for the AWS cli with the role ARNs and specifies that AWS should use its EC2 instance profile to assume these roles. This means we don't need to worry about MFA when running the validate-cloudtrail-logs script on Jenkins with the correct profile. A new Ansible task takes care of adding this config file.