### PR TITLE
Add DOS4 to supplier export job

### DIFF
--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -1,6 +1,7 @@
 {% set environments = ['preview', 'staging', 'production'] %}
 {% set frameworks = [
-    'g-cloud-9', 'g-cloud-10', 'g-cloud-11', 'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3'
+    'g-cloud-9', 'g-cloud-10', 'g-cloud-11',
+    'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3', 'digital-outcomes-and-specialists-4'
   ]
 %}
 ---


### PR DESCRIPTION
https://trello.com/c/c96F11bZ/553-add-dos4-to-export-supplier-data-to-s3-jenkins-job

One of the steps in the DOS framework prep. This job generates a CSV of supplier details and stores it in S3, ready for the framework manager to download and use when sending Notify emails.

There won't be any suppliers in the file until the framework opens, but the script should run fine as long as the framework object is in the database (which it now is). 