### PR TITLE
570-apply-db-dump-to-preview-success-slack-message-goes-to-dm-2ndline-should-it-go-to-dm-release-instead

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -13,13 +13,13 @@
 {% endif %}
     dsl: |
 
-      def notify_slack(icon, status) {
+      def notify_slack(icon, status, channel = "#dm-release") {
         build job: "notify-slack",
         parameters: [
           string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
-          string(name: 'CHANNEL', value: "#dm-2ndline"),
+          string(name: 'CHANNEL', value: channel),
           text(name: 'STAGE', value: "{{ environment }}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
@@ -142,7 +142,7 @@
               notify_slack(':shower:', 'SUCCESS')
 
             } catch(err) {
-              notify_slack(':sadparrot:', 'FAILED')
+              notify_slack(':sadparrot:', 'FAILED', "#dm-2ndline")
               echo "Error caught"
               currentBuild.result = 'FAILURE'
               echo "Error: ${err}"


### PR DESCRIPTION


* Update `def notify_slack` to match elsewhere where we conditionally change the channel
  * As per https://github.com/alphagov/digitalmarketplace-jenkins/blob/master/job_definitions/smoke_smoulder_tests.yml
* Pass in the 2ndline channel only in the event of a failure (indicating action should be taken)


https://trello.com/c/2RNANM8K/570-apply-db-dump-to-preview-success-slack-message-goes-to-dm-2ndline-should-it-go-to-dm-release-instead