### PR TITLE
923-make-apply-db-dump-to-stage-job-use-parallel-indexing

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -106,6 +106,7 @@
                     string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
                     string(name: 'FRAMEWORKS', value: "{{ search_config['services'][environment].frameworks }}"),
                     string(name: 'MAPPING', value: "{{ search_config['services'][environment].default_mapping_name }}"),
+                    bool(name: 'SERIAL', value: false),
                   ]
                 }
                 stage('Update index alias'){
@@ -126,6 +127,7 @@
                     string(name: 'INDEX_NAME', value: "${INDEX_NAME}"),
                     string(name: 'FRAMEWORKS', value: "{{ search_config['briefs'][environment].frameworks }}"),
                     string(name: 'MAPPING', value: "{{ search_config['briefs'][environment].default_mapping_name }}"),
+                    bool(name: 'SERIAL', value: false),
                   ]
                 }
                 stage('Update index alias'){


### PR DESCRIPTION
This job takes forever, and it will be worse on G11.

The default in
https://github.com/alphagov/digitalmarketplace-jenkins/blob/master/job_definitions/create_index.yml#L38

is to run it serial.

We should switch the apply-cleaned-db job to use parallel indexing.

https://trello.com/c/oeZifKam/923-make-apply-db-dump-to-stage-job-use-parallel-indexing