### PR TITLE
Update indexing jobs to use G11

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -268,14 +268,14 @@ search_config:
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
     preview:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
+      default_index: g-cloud-11
+      frameworks: g-cloud-11
+      default_mapping_name: services-g-cloud-11
     staging:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
+      default_index: g-cloud-11
+      frameworks: g-cloud-11
+      default_mapping_name: services-g-cloud-11
     production:
-      default_index: g-cloud-10
-      frameworks: g-cloud-10
-      default_mapping_name: services-g-cloud-10
+      default_index: g-cloud-11
+      frameworks: g-cloud-11
+      default_mapping_name: services-g-cloud-11


### PR DESCRIPTION
https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html#g-cloud

The `index_service` jobs and the `clean_and_apply_db_dump` jobs use Jenkins' `search_config` to determine which framework to use.

We'll need to apply this just before G11 goes live (see manual link above, which needs a little bit of polishing to refer to the newish structure of the indexing jobs).