### PR TITLE
Disable G10 countersigning, enable G11

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -1,8 +1,8 @@
 {% set environments = ['production'] %}
 {% set frameworks = [
     ('DOS3', 'digital-outcomes-and-specialists-3', False),
-    ('G10', 'g-cloud-10', False),
-    ('G11', 'g-cloud-11', True),
+    ('G10', 'g-cloud-10', True),
+    ('G11', 'g-cloud-11', False),
   ]
 %}
 ---


### PR DESCRIPTION
We're ready to start countersigning G11 documents en masse.

The Notify template is framework-agnostic, so no changes are required there.