### PR TITLE
Update performance platform jobs for DOS4

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -1,5 +1,5 @@
 {% set environments = ['production'] %}
-{% set frameworks = [('g-cloud-11', 'true')] %}
+{% set frameworks = [('digital-outcomes-and-specialists-4', 'true')] %}
 ---
 {% for environment in environments %}
 {% for framework, disabled in frameworks %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,5 +1,5 @@
 {% set environments = ['production'] %}
-{% set frameworks = [('g-cloud-11', 'gcloud', 'g-cloud', 'true')] %}
+{% set frameworks = [('digital-outcomes-and-specialists-4', 'digital-outcomes-specialists', 'digital-outcomes-specialists', 'true')] %}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 ---
 {% for environment in environments %}


### PR DESCRIPTION
https://trello.com/c/OOHw1Brm/31-set-up-dos4-performance-platform-dashboard

Configure the two stats jobs ready for DOS4 opening on Monday. Both jobs are disabled for now.