### PR TITLE
593-alert-slack-when-db-refresh-job-starts

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -78,6 +78,7 @@
               }
 
               stage('Apply data to target stage and s3') {
+                notify_slack(':building_blue:', 'APPROVED', "#dm-release")
                 sh(
                    script: '''
                      export TARGET="{{ environment }}"


### PR DESCRIPTION
* Alert in #dm-release when a db refresh starts running

https://trello.com/c/R2A3edQO/593-alert-slack-when-db-refresh-job-starts