### PR TITLE
Use Dockerfile for building manual

### DIFF
--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -15,8 +15,13 @@
           cron: "H/2 * * * *"
     builders:
       - shell: |
-          [ -x /tmp/dm-manual-venv/bin/pip ] || virtualenv /tmp/dm-manual-venv
-          . /tmp/dm-manual-venv/bin/activate
+          docker pull digitalmarketplace/manual || true
+          docker build --pull -t digitalmarketplace/manual .
+          docker push digitalmarketplace/manual
 
-          pip install -r requirements.txt
-          make clean html pages
+          docker run -it --rm \
+            -v $(pwd):/app \
+            digitalmarketplace/manual \
+            make clean html
+          
+          make pages


### PR DESCRIPTION
https://trello.com/c/I6n0Dx9k/930-publish-manual-job-needs-love

Requires https://github.com/alphagov/digitalmarketplace-manual/pull/197 to be merged and the docker repo `digitalmarketplace-manual` to be created on Docker Hub.

This PR changes the manual job to build the html in a Docker container with Sphinx already installed. This means we don't need a virtualenv or pyenv for this job.