### PR TITLE
Fix validate-cloudtrail-logs

### DIFF
--- a/job_definitions/validate_cloudtrail_logs.yml
+++ b/job_definitions/validate_cloudtrail_logs.yml
@@ -27,10 +27,12 @@
       - shell: |
           docker run --rm \
             -v /var/lib/jenkins/digitalmarketplace-credentials:/digitalmarketplace-credentials \
+            -v $HOME/.aws:/root/.aws \
             -e DM_CREDENTIALS_REPO=/digitalmarketplace-credentials \
-            -e VERBOSE=$VERBOSE \
+            -e VERBOSE="$VERBOSE" \
             digitalmarketplace/scripts \
-            scripts/validate-cloudtrail-logs.sh $ACCOUNT $START_FROM $UP_TO
+            scripts/validate-cloudtrail-logs.sh "$ACCOUNT" "$START_FROM" "$UP_TO"
+
 
 - job:
     name: validate-cloudtrail-logs-periodic

--- a/playbooks/roles/jenkins/templates/aws_config.j2
+++ b/playbooks/roles/jenkins/templates/aws_config.j2
@@ -1,7 +1,7 @@
 {% for role in assume_roles %}
 
 [profile {{role.profile.name}}]
-credentials_source=Ec2InstanceMetadata
+credential_source=Ec2InstanceMetadata
 region={{role.profile.region}}
 role_arn={{role.profile.role_arn}}
 {% endfor %}


### PR DESCRIPTION
- Missing quotation marks caused '3 days ago' to be split into multiple words.
- aws-cli config dir needed to be mounted into the container.
- Typo in aws-cli config