### PR TITLE
Pin cf-cli to 0.63.*

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_paas.yml
+++ b/playbooks/roles/jenkins/tasks/05_paas.yml
@@ -11,6 +11,6 @@
 
 - name: Install or update CloudFoundry package
   apt:
-    name: "cf-cli"
-    state: latest
+    name: cf-cli=6.33.*
+    state: present
     update_cache: yes


### PR DESCRIPTION
cf-cli analyses manifest files using multiple passes of the file
descriptor, which means that using process substitution (`<()`) with
generate manifest doesn't always work (c.f. #74).

The long term fix is to rework our deploy scripts so we don't need to
use process substitution with the manifests, but for now the workaround
is to downgrade cf-cli.