### PR TITLE
Add play to ensure Amazon CloudWatch Agent is started on boot

### DIFF
--- a/playbooks/roles/jenkins/tasks/00_amazon_cloudwatch_agent.yml
+++ b/playbooks/roles/jenkins/tasks/00_amazon_cloudwatch_agent.yml
@@ -8,6 +8,11 @@
   apt:
     deb: /tmp/amazon-cloudwatch-agent.deb
 
+- name: Ensure Amazon CloudWatch agent is started on boot
+  service:
+    name: amazon-cloudwatch-agent
+    enabled: true
+
 - name: Create amazon-cloudwatch-agent.json file in /opt/aws/amazon-cloudwatch-agent/etc directory
   template: src=amazon-cloudwatch-agent.json.j2 dest=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json mode=600
   notify: restart amazon-cloudwatch-agent


### PR DESCRIPTION
https://trello.com/c/o8DM6mYM/949-fix-jenkins-disk-space-warnings

We've been having issues where the amazon-cloudwatch-agent service has not been starting on boot (although that is the vendor preset). This commit adds a play to make sure it does.