### PR TITLE
85-manual-entry-adding-a-docker-container-that-gets-auto-updated

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -12,6 +12,7 @@
             - {{ application }}
 {% endfor %}
             - scripts
+            - manual
       - string:
           name: RELEASE_NAME
           description: "git ref (eg 'release-42') to checkout for building the artefact. This will also become the image release name."

--- a/job_definitions/build_scripts.yml
+++ b/job_definitions/build_scripts.yml
@@ -8,45 +8,10 @@
       - pollscm:
           cron: "* * * * *"
     dsl: |
-
-      def tag_release(tag) {
-        try {
-          sh("git config user.name 'Jenkins'")
-          sh("git config user.email '{{ jenkins_github_email }}'")
-          sh("git tag -a ${tag} -m ${tag}")
-          sh("git push origin ${tag} -f")
-        } catch(e) {
-          echo "${tag} tag already exists"
-        }
-      }
-
-      stage('Create release tag') {
-        node {
-          git url: "git@github.com:alphagov/digitalmarketplace-scripts.git",
-              branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
-          releaseNumber = sh(
-              script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
-              returnStdout: true
-          ).trim()
-
-          if (releaseNumber == "") {
-              throw new Exception('Release number can not be found')
-          }
-
-          releaseName = "release-${releaseNumber}"
-
-          tag_release(releaseName)
-
-          echo "Release number: ${releaseNumber}"
-          currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
-        }
-      }
-
       stage('Build') {
         node {
-          build job: "build-image", parameters: [
+          build job: "tag-release-and-build-image", parameters: [
             string(name: "REPOSITORY", value: "scripts"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
           ]
         }
       }

--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -2,7 +2,7 @@
 - job:
     name: 'publish-manual'
     display: "Publish manual"
-    project-type: freestyle
+    project-type: pipeline
     description: "Automatically publish digitalmarketplace manual to gh pages."
     scm:
       - git:
@@ -13,19 +13,30 @@
     triggers:
       - pollscm:
           cron: "H/2 * * * *"
-    builders:
-      - shell: |
-          docker pull digitalmarketplace/manual || true
-          docker build --pull -t digitalmarketplace/manual .
-          docker push digitalmarketplace/manual
+    dsl: |
+      node {
+        stage('Prepare') {
+          sh("git config user.name 'Jenkins'")
+          sh("git config user.email '{{ jenkins_github_email }}'")
+          git url: "git@github.com:alphagov/digitalmarketplace-manual.git", branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+        }
 
-          DOCKER_UID="$(id -u)"
-          DOCKER_GID="$(getent group docker | awk -F ':' '{print $3}')"
+        stage('Build') {
+          build job: "tag-release-and-build-image", parameters: [
+            string(name: "REPOSITORY", value: "manual")
+          ]
+        }
 
-          docker run --rm \
-            -u $DOCKER_UID:$DOCKER_GID \
-            -v $(pwd):/app \
-            digitalmarketplace/manual \
-            make clean html
+        stage('Make HTML') {
+          script {
+            env.DOCKER_UID = sh(script:"id -u", returnStdout: true).trim()
+            env.DOCKER_GID = sh(script:"getent group docker | awk -F ':' '{print \$3}'", returnStdout: true).trim()
 
-          make pages
+            sh(script:"docker run --rm -u ${env.DOCKER_UID}:${env.DOCKER_GID} -v \$(pwd):/app digitalmarketplace/manual make clean html")
+          }
+        }
+
+        stage('Push pages') {
+          sh("make pages")
+        }
+      }

--- a/job_definitions/tag_release_and_build_image.yml
+++ b/job_definitions/tag_release_and_build_image.yml
@@ -1,0 +1,57 @@
+- job:
+    name: tag-release-and-build-image
+    display-name: Tag release and build docker image
+    project-type: pipeline
+    description: Tag a repo with the current merge commit number and build its Docker image
+    concurrent: true
+    parameters:
+      - choice:
+          name: REPOSITORY
+          choices:
+{% for application in dm_applications %}
+            - {{ application }}
+{% endfor %}
+            - scripts
+            - manual
+    dsl: |
+      def tag_release(tag) {
+        try {
+          sh("git config user.name 'Jenkins'")
+          sh("git config user.email '{{ jenkins_github_email }}'")
+          sh("git tag -a ${tag} -m ${tag}")
+          sh("git push origin ${tag} -f")
+        } catch(e) {
+          echo "${tag} tag already exists"
+        }
+      }
+
+      stage('Create release tag') {
+        node {
+          git url: "git@github.com:alphagov/digitalmarketplace-${REPOSITORY}.git",
+              branch: 'master', credentialsId: 'github_com_and_enterprise', poll: true
+          releaseNumber = sh(
+              script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
+              returnStdout: true
+          ).trim()
+
+          if (releaseNumber == "") {
+              throw new Exception('Release number can not be found')
+          }
+
+          releaseName = "release-${releaseNumber}"
+
+          tag_release(releaseName)
+
+          echo "Release number: ${releaseNumber}"
+          currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
+        }
+      }
+
+      stage('Build') {
+        node {
+          build job: "build-image", parameters: [
+            string(name: "REPOSITORY", value: "${REPOSITORY}"),
+            string(name: "RELEASE_NAME", value: "${releaseName}"),
+          ]
+        }
+      }


### PR DESCRIPTION
In `build-scripts` and `release-pipeline` exactly the same code was copy pasted. This code can also be used to update the docker image for the `manual` job.

* Add a new job `tag-release-and-build-image`
  * Add the steps from `build-scripts` and `release-pipeline` that are duplicated
* Remove duplication from `build-scripts` and `release-pipeline`
* Remove bash commands doing effectively the same thing from `manual`
* Use new job in `build-scripts`, `release-pipeline` and `manual`