### PR TITLE
Prune local tags that do not exist in remote

### DIFF
--- a/job_definitions/tag_release_and_build_image.yml
+++ b/job_definitions/tag_release_and_build_image.yml
@@ -18,6 +18,7 @@
         try {
           sh("git config user.name 'Jenkins'")
           sh("git config user.email '{{ jenkins_github_email }}'")
+          sh("git fetch --prune origin '+refs/tags/*:refs/tags/*'")
           sh("git tag -a ${tag} -m ${tag}")
           sh("git push origin ${tag} -f")
         } catch(e) {


### PR DESCRIPTION
https://trello.com/c/yEdL41wX/1032-manual-job-wont-publish-jenkins-snafu

We use the `tag-release-and-build-image` workspace to check out and tag a number of different repos. Running `git tag` when tagging the manual shows a load of release tags not relevant to that repo.

This PR adds a line to prune local tags that don't exist on the remote. 

Can someone with advanced git-fu take a look at this? Would there be any hidden problems? I'm pretty sure two different repos can't be simultaneously tagged-and-built, the jobs are queued up by Jenkins in series.