### PR TITLE
Disable DOS4 performance platform jobs

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -1,5 +1,5 @@
 {# frameworks = (framework_slug, enabled?) #}
-{% set frameworks = [('digital-outcomes-and-specialists-4', True)] %}
+{% set frameworks = [('digital-outcomes-and-specialists-4', False)] %}
 {% set environments = ['production'] %}
 ---
 {% for environment in environments %}

--- a/job_definitions/stats_to_performance_platform.yml
+++ b/job_definitions/stats_to_performance_platform.yml
@@ -1,6 +1,6 @@
 {# frameworks = (framework_slug, performance_platform_service, token_group, enabled?) #}
 {% set frameworks = [
-  ('digital-outcomes-and-specialists-4', 'digital-outcomes-specialists', 'digital-outcomes-specialists', True)
+  ('digital-outcomes-and-specialists-4', 'digital-outcomes-specialists', 'digital-outcomes-specialists', False)
 ]%}
 {% set schedules = [('1 */1 *  * *', 'hour'), ('1 0 * * *', 'day')] %}
 {% set environments = ['production'] %}


### PR DESCRIPTION
https://trello.com/c/GiRAieAw/142-close-dos4-applications-and-export-data

After applications close we'll want to turn off the performance platform stats jobs in Jenkins. Let's have this PR ready to go for the 15th 👍 