### PR TITLE
Delete line missed by revert

### DIFF
--- a/job_definitions/manual.yml
+++ b/job_definitions/manual.yml
@@ -30,4 +30,3 @@
             make clean html
 
           make pages
-      }


### PR DESCRIPTION
I accidentally missed a closing bracket that was left in by the revert when approving #261 