### PR TITLE
New job for mark-definite-framework-results framework script

### DIFF
--- a/job_definitions/mark_definite_framework_results.yml
+++ b/job_definitions/mark_definite_framework_results.yml
@@ -1,0 +1,44 @@
+{% for environment in ['preview', 'production'] %}
+- job:
+    name: "mark-definite-framework-results-{{ environment }}"
+    display-name: "Mark definite framework results - {{ environment }}"
+    project-type: freestyle
+    disabled: true
+    description: |
+      This job runs the mark-definite-framework-results script at the end of a framework application period. It should
+       be triggered manually, after suppliers have been notified whether they made an application or not.
+      The script sets the 'onFramework' value for each supplier application in the database, based on their declaration
+      answers. The JSON schemas in the scripts repo determine which answers are a 'pass', which are a 'fail', and which
+      are a 'discretionary pass'. This script ignores discretionary passes (the database values are left as 'null').
+
+    parameters:
+      - string:
+          name: FRAMEWORK_SLUG
+          description: "The framework slug to set results for, e.g. 'g-cloud-11'."
+      - string:
+          name: PASS_SCHEMA
+          description: "Path to the declaration assessment schema in the scripts repo, e.g. 'schemas/digital-outcomes-and-specialists-4.declaration.json'"
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "Dry run - do not set values in the database"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=mark-definite-framework-results
+              JOB=Mark definite framework results {{ environment }}
+              ICON=:heavy_check_mark:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+    builders:
+      - shell: |
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/framework-applications/mark-definite-framework-results.py '{{ environment }}' "${FRAMEWORK_SLUG}" "${PASS_SCHEMA}" $FLAGS
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -202,6 +202,8 @@ jenkins_list_views:
   - name: "Framework lifecycle jobs"
     jobs:
       - generate-upload-and-notify-counterpart-signature-pages-production
+      - mark-definite-framework-results-preview
+      - mark-definite-framework-results-production
       - notify-suppliers-whether-application-made-for-framework-production
       - scan-g-cloud-services-for-bad-words
       - stats-performance-platform-digital-outcomes-and-specialists-4-per-hour-production


### PR DESCRIPTION
https://trello.com/c/Q7qwyzGj/221-the-mark-definite-framework-results-script-should-be-a-jenkins-job

Jenkins job to run this script: https://github.com/alphagov/digitalmarketplace-scripts/blob/master/scripts/framework-applications/mark-definite-framework-results.py

Included `preview` so we can test this - we can remove it later.