### PR TITLE
Add success Slack notification

### DIFF
--- a/job_definitions/mark_definite_framework_results.yml
+++ b/job_definitions/mark_definite_framework_results.yml
@@ -29,10 +29,20 @@
             predefined-parameters: |
               USERNAME=mark-definite-framework-results
               JOB=Mark definite framework results {{ environment }}
-              ICON=:heavy_check_mark:
+              ICON=:heavy_multiplication_x:
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
+          - project: notify-slack
+            condition: SUCCESS
+            predefined-parameters: |
+              USERNAME=mark-definite-framework-results
+              JOB=Mark definite framework results {{ environment }}
+              ICON=:heavy_check_mark:
+              STAGE={{ environment }}
+              STATUS=SUCCESS
+              URL=<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>
               CHANNEL=#dm-release
     builders:
       - shell: |


### PR DESCRIPTION
https://trello.com/c/Q7qwyzGj/221-the-mark-definite-framework-results-script-should-be-a-jenkins-job

The job only had a failure Slack notification - given this job will take a while and it'll be handy to know when it's finished, let's add a success notification.