### PR TITLE
Split DOS opportunity CSV export into separate job

### DIFF
--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -5,7 +5,7 @@
     name: "export-data-{{ environment }}"
     display-name: "Export API model data as CSV - {{ environment }}"
     project-type: freestyle
-    description: "Runs the get-model-data.py script and uploads the generated CSV files to Google Drive (everything, for us) and S3 (just the opportunity data, for the public)"
+    description: "Runs the get-model-data.py script and uploads the generated CSV files to Google Drive."
     triggers:
       - timed: "H 5 * * *"
     publishers:
@@ -28,7 +28,6 @@
           rm -rf ./data && mkdir data
 
           docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py '{{ environment }}'
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/upload-file-to-s3.py data/opportunity-data.csv digitalmarketplace-communications-{{ environment }}-{{ environment }} digital-outcomes-and-specialists-3/communications/data/opportunity-data.csv opportunity-data.csv --public
 
           {% if environment == "production" %}
           /usr/local/bin/gdrive --config "/var/lib/jenkins/.gdrive" sync upload --delete-extraneous ./data "{{ jenkins_gdrive_csv_data_export_folder_id }}"

--- a/job_definitions/export_dos_opportunities.yml
+++ b/job_definitions/export_dos_opportunities.yml
@@ -1,0 +1,32 @@
+{% set environments = ['preview', 'staging', 'production'] %}
+---
+{% for environment in environments %}
+- job:
+    name: "export-dos-opportunities-{{ environment }}"
+    display-name: "Export DOS opportunities as CSV - {{ environment }}"
+    project-type: freestyle
+    description: "Runs the export-dos-opportunities.py script and uploads the generated CSV file to the (public) communications S3 bucket"
+    triggers:
+      - timed: "H 4 * * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=export-dos-opportunities
+              JOB=Export data {{ environment }}
+              ICON=:no-dos:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-2ndline
+    builders:
+      - shell: |
+
+          # We need to recreate the directory manually since the one created by Docker
+          # when mounting the volume will otherwise be owned by the root user.
+          rm -rf ./data && mkdir data
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/export-dos-opportunities.py '{{ environment }}'
+
+{% endfor %}

--- a/job_definitions/export_dos_opportunities.yml
+++ b/job_definitions/export_dos_opportunities.yml
@@ -1,4 +1,4 @@
-{% set environments = ['preview', 'staging', 'production'] %}
+{% set environments = ['preview', 'production'] %}
 ---
 {% for environment in environments %}
 - job:

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -116,6 +116,9 @@ jenkins_list_views:
       - data-retention-production
       - export-data-preview
       - export-data-production
+      - export-dos-opportunities-preview
+      - export-dos-opportunities-staging
+      - export-dos-opportunities-production
       - export-supplier-csv-preview
       - export-supplier-csv-staging
       - export-supplier-csv-production

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -117,7 +117,6 @@ jenkins_list_views:
       - export-data-preview
       - export-data-production
       - export-dos-opportunities-preview
-      - export-dos-opportunities-staging
       - export-dos-opportunities-production
       - export-supplier-csv-preview
       - export-supplier-csv-staging


### PR DESCRIPTION
https://trello.com/c/N3yUHHOe/92-make-dos-outcome-csv-framework-iteration-agnostic

New Jenkins job for the DOS opportunity export script (see https://github.com/alphagov/digitalmarketplace-scripts/pull/432).

Removes the S3 upload script call from the existing `export_data` job.

~I've included the `staging` env as all of our environments should have the public CSV available to download from the [DOS search page](https://www.staging.marketplace.team/digital-outcomes-and-specialists/opportunities).~ Double checking just now, it looks like we hardcode this to the production bucket anyway 🤦‍♀, added a commit to take out `staging`. 