### PR TITLE
Update DOS opportunities email job in Jenkins tabs

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -103,7 +103,7 @@ build_monitor_jobs:
   - index-services-preview
   - index-services-production
   - notify-buyers-when-requirements-close-production
-  - notify-suppliers-of-dos3-opportunities-production
+  - notify-suppliers-of-dos-opportunities-production
   - notify-suppliers-of-new-questions-answers-production
   - upload-dos3-opportunities-email-list-production
   - visual-regression-preview
@@ -160,7 +160,7 @@ jenkins_list_views:
       - notify-buyers-to-award-closed-briefs-8-weeks-production
       - notify-buyers-when-requirements-close-production
       - notify-suppliers-of-awarded-briefs-production
-      - notify-suppliers-of-dos3-opportunities-production
+      - notify-suppliers-of-dos-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-production
       - upload-dos3-opportunities-email-list-production


### PR DESCRIPTION
https://trello.com/c/58q6lRKF/33-update-dos4-regular-email-jobs

The DOS opportunities email job got renamed in https://github.com/alphagov/digitalmarketplace-jenkins/pull/268. The config needs to be updated as well, to show the new job name in the correct tab and on the build monitor view.