### PR TITLE
Turn on countersigning for DOS4 agreements

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -1,6 +1,7 @@
 {# frameworks = (acronym, framework_slug, enabled?) #}
 {% set frameworks = [
-  ('DOS3', 'digital-outcomes-and-specialists-3', True),
+  ('DOS4', 'digital-outcomes-and-specialists-4', True),
+  ('DOS3', 'digital-outcomes-and-specialists-3', False),
   ('G10', 'g-cloud-11', False),
   ('G11', 'g-cloud-11', True),
 ]%}


### PR DESCRIPTION
https://trello.com/c/FwdsekGo/286-generate-first-countersigned-dos4-agreement-pdf-for-all-lots-and-send-to-ccs

Standstill is now over and we can begin countersigning DOS4 agreements for suppliers who've returned their signed framework agreement page.

We no longer need to generate countersigned pages for DOS3 suppliers via Jenkins (we can still do it manually if we need to).