### PR TITLE
Add DOS4 to list of frameworks to index briefs for

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -271,15 +271,15 @@ search_config:
   briefs:
     preview:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3,digital-outcomes-and-specialists-4
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
     staging:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3,digital-outcomes-and-specialists-4
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
     production:
       default_index: briefs-digital-outcomes-and-specialists
-      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3
+      frameworks: digital-outcomes-and-specialists,digital-outcomes-and-specialists-2,digital-outcomes-and-specialists-3,digital-outcomes-and-specialists-4
       default_mapping_name: briefs-digital-outcomes-and-specialists-2
   services:
     preview:


### PR DESCRIPTION
https://trello.com/c/TWbsBQ02/24-review-dos4-brief-indexing

This is to include DOS4 briefs in the overnight indexing catchup job.

To be merged after go-live on Oct 1st. Will require a Jenkins config reload.

