### PR TITLE
Upload suppliers to the DOS4 mailing lists

### DIFF
--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -1,4 +1,4 @@
-{% set framework_slugs = ['digital-outcomes-and-specialists-3'] %}
+{% set framework_slugs = ['digital-outcomes-and-specialists-4'] %}
 ---
 {% for framework_slug in framework_slugs %}
 - job:

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -105,7 +105,7 @@ build_monitor_jobs:
   - notify-buyers-when-requirements-close-production
   - notify-suppliers-of-dos-opportunities-production
   - notify-suppliers-of-new-questions-answers-production
-  - upload-dos3-opportunities-email-list-production
+  - upload-dos4-opportunities-email-list-production
   - visual-regression-preview
 
 jenkins_list_views:


### PR DESCRIPTION
https://trello.com/c/58q6lRKF/33-update-dos4-regular-email-jobs

Suppliers can now be added to the Mailchimp mailing lists for each lot.

This needs to be merged before Oct 2nd when we'll start sending the alert emails for newly published DOS4 briefs.