### PR TITLE
generate_upload_and_notify_counterpart_signature_pages: add `wheel` package to venv

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -56,6 +56,7 @@
 
                   make virtualenv
                   ./venv/bin/pip install --upgrade pip
+                  ./venv/bin/pip install wheel  # this allows pip to cache compiled packages instead of rebuilding them all on every invocation
                   make requirements
                 ''')
               }

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -102,7 +102,7 @@
               string(name: 'ICON', value: ':alarm_clock:'),
               string(name: 'STAGE', value: "${ENVIRONMENT}"),
               string(name: 'STATUS', value: 'FAILED'),
-              string(name: 'CHANNEL', value: '#dm-2ndline'),
+              string(name: 'CHANNEL', value: ENVIRONMENT == 'production' ? '#dm-2ndline' : '#dm-release'),
               text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
             ]
           }


### PR DESCRIPTION
This allows pip to cache compiled packages and avoid rebuilding them all on every invocation. Which seems like it occupies a significant amount of the runtime of this script.

Also stop this script annoying `#dm-2ndline` for non-production failures.

Need I say, this is actually already deployed and working.