### PR TITLE
Add visual regression tests job to staging

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -13,6 +13,43 @@
 {% endif %}
     dsl: |
 
+      def run_visual_regression_tests(stage) {
+        def job_name = "visual-regression-${stage}"
+        def vr_job = null
+
+        node {
+          vr_job = build job: job_name, parameters: [
+            string(name: "COMMAND", value: "test"),
+          ], propagate: false
+        }
+
+        def vr_job_result = vr_job.result
+        def vr_job_number = vr_job.number
+        vr_job = null
+
+        if (vr_job_result == 'SUCCESS') {
+          return true
+        } else {
+          echo "Visual regression tests build result: ${vr_job_result}"
+
+          echo "Assuming that these changes are due to database restore. Approving."
+          try {
+            node {
+              build job: job_name, parameters: [
+                string(name: "COMMAND", value: "approve"),
+              ]
+            }
+
+          } catch(inside_error) {
+            echo "Approving visual regression tests failed: ${inside_error}"
+            currentBuild.result = 'UNSTABLE'
+            return false
+          }
+
+          return true
+        }
+      }
+
       def notify_slack(icon, status, channel = "#dm-release") {
         build job: "notify-slack",
         parameters: [
@@ -138,6 +175,13 @@
                     string(name: 'DELETE_OLD_INDEX', value: 'yes')
                   ]
                 }
+              }
+{% endif %}
+
+
+{% if environment in ['preview'] %}
+              stage('Run visual regression tests') {
+                run_visual_regression_tests("{{ environment }}")
               }
 {% endif %}
 

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -179,7 +179,7 @@
 {% endif %}
 
 
-{% if environment in ['preview'] %}
+{% if environment in ['preview', 'staging'] %}
               stage('Run visual regression tests') {
                 run_visual_regression_tests("{{ environment }}")
               }

--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -255,6 +255,12 @@
         milestone()
       }
 
+      stage('Visual regression tests - staging') {
+        milestone()
+        run_visual_regression_tests("staging")
+        milestone()
+      }
+
       {% if application in dm_db_applications %}
       stage('DB migration on production') {
         milestone()

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -1,5 +1,5 @@
-{% set environment = "preview" %}
 ---
+{% for environment in ("preview", "staging") %}
 - job:
     name: "visual-regression-{{ environment }}"
     display-name: "Visual regression - {{ environment }}"
@@ -159,3 +159,4 @@
                   STATUS=APPROVED
                   URL=<${BUILD_URL}Visual_Regression_Test_Report|${BUILD_DISPLAY_NAME}>
                   CHANNEL=#dm-release
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -154,6 +154,7 @@ jenkins_list_views:
       - functional-tests-preview
       - functional-tests-staging
       - visual-regression-preview
+      - visual-regression-staging
   - name: "Emails"
     jobs:
       - notify-buyers-to-award-closed-briefs-4-weeks-production


### PR DESCRIPTION
Ticket: https://trello.com/c/LxcD30hu/55-add-visual-regression-tests-against-staging-to-release-pipeline

We want to be able to check whether changes we are releasing will cause visual regressions.

This commit adds a visual-regressions-staging job, and sets it to be automatically run as part of the release pipeline for an app.

We also make sure visual regressions are run against staging when restoring a database dump. ~I copied the function from the release pipeline that asks for user input if the visual regression tests fail. Since we're expecting the visual regression tests to fail this does mean we'll have to check them weekly to approve them; alternatively we could approve automatically.~ I've added a function that runs the visual regression tests and automatically approves the changes.