### PR TITLE
Job to auto-tag DM GOVUK frontend

### DIFF
--- a/job_definitions/tag_digitalmarketplace_govuk_frontend.yml
+++ b/job_definitions/tag_digitalmarketplace_govuk_frontend.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: 'tag-digitalmarketplace-govuk-frontend'
+    display-name: "Tag Digital Marketplace GOV.UK Frontend"
+    project-type: freestyle
+    description: "Push the git tag on the https://github.com/alphagov/digitalmarketplace-govuk-frontend repository."
+    properties:
+      - build-discarder:
+          days-to-keep: 20
+          artifact-days-to-keep: 20
+    scm:
+      - git:
+          url: git@github.com:alphagov/digitalmarketplace-govuk-frontend.git
+          credentials-id: github_com_and_enterprise
+          branches:
+            - master
+          skip-tag: true
+    triggers:
+      - pollscm:
+          cron: "H/2 * * * *"
+    wrappers:
+      - ansicolor
+    builders:
+      - shell: |
+          git config user.name "Jenkins"
+          ./scripts/tag_latest_version.sh
+          git push origin --tags

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -178,6 +178,7 @@ jenkins_list_views:
       - publish-toolkit-documentation
       - rerelease-all-apps
       - tag-application-deloyment
+      - tag-digitalmarketplace-govuk-frontend
       - tag-dmapiclient
       - tag-dmcontent-loader
       - tag-dmutils


### PR DESCRIPTION
https://trello.com/c/bzsVPMU3/57-jenkins-job-to-auto-tag-digitalmarketplace-govuk-frontend-releases

Polls the digitalmarketplace-govuk-frontend repo for changes to `master`, and runs the tagging script introduced by https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/20.

Based on the very similar [FE toolkit tagging job](https://github.com/alphagov/digitalmarketplace-jenkins/blob/master/job_definitions/toolkit.yml).
