### PR TITLE
Preview/staging failure alerts should be sent to #dm-release

### DIFF
--- a/job_definitions/data_retention.yml
+++ b/job_definitions/data_retention.yml
@@ -24,7 +24,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-2ndline
+              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/export_data.yml
+++ b/job_definitions/export_data.yml
@@ -19,7 +19,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-2ndline
+              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
     builders:
       - shell: |
 

--- a/job_definitions/export_dos_opportunities.yml
+++ b/job_definitions/export_dos_opportunities.yml
@@ -19,7 +19,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-2ndline
+              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
     builders:
       - shell: |
 

--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -24,7 +24,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-2ndline
+              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
     builders:
       - shell: |
 


### PR DESCRIPTION
https://trello.com/c/qXIlBIBT/1215-move-preview-slack-alerts-out-of-dm2ndline-channel

Jenkins job failures for preview and staging environments should go to the `#dm-release` slack channel, to avoid noise in the `#dm-2ndline` channel and generally reduce the blood pressure of developers on the support rota. 