### PR TITLE
1221-remove-jenkins-green-balls-plugin

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -71,7 +71,6 @@ jenkins_plugins:
   - git
   - github
   - github-oauth
-  - greenballs
   - htmlpublisher
   - lockable-resources
   - next-executions


### PR DESCRIPTION
https://trello.com/c/V0zF3eOK/1221-remove-jenkins-green-balls-plugin

* Remove greenballs because it is no longer maintained