### PR TITLE
Add trigger to run visual regression tests after change

### DIFF
--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -25,6 +25,9 @@
           branches:
             - "master"
           wipe-workspace: false
+    triggers:
+      - pollscm:
+          cron: "H/2 * * * *"
     wrappers:
       - ansicolor
     publishers:


### PR DESCRIPTION
We want to make sure that any changes to our visual regression tests get
highlighted in a separate run; this commit adds a pollscm trigger that
runs the visual regression tests after a merge to master of the visual
regression tests repo, then we can see the impact automatically.