### PR TITLE
Bump Ansible requirement to 2.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.8.1
+ansible==2.8.6


### PR DESCRIPTION
Dependabot raised a nearly-useful PR to bump Ansible, but it was a couple of patch bumps short: https://github.com/alphagov/digitalmarketplace-jenkins/pull/281

The Ansible changelog is here, no breaking changes as far as I can see: https://github.com/ansible/ansible/blob/stable-2.8/changelogs/CHANGELOG-v2.8.rst
