### PR TITLE
add rotate-ft-account-passwords job

### DIFF
--- a/job_definitions/rotate_ft_account_passwords.yml
+++ b/job_definitions/rotate_ft_account_passwords.yml
@@ -1,0 +1,93 @@
+---
+- job:
+    name: "rotate-ft-account-passwords"
+    display-name: "Rotate functional test account passwords"
+    project-type: pipeline
+    description: "Regenerates passwords for all DMP accounts found in jenkins' functional/smoke/smoulder tests section of the credentials repo, then synchronizes them via the API"
+    parameters:
+      - choice:
+          name: STAGE
+          choices:
+            - preview
+            - staging
+            - production
+    dsl: |
+      currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"
+      node {
+        stage("Generate new FT account passwords") {
+          sh('''
+            docker run --rm \
+              -v $HOME/.aws:/root/.aws \
+              -e GITHUB_ACCESS_TOKEN \
+              digitalmarketplace/scripts \
+              scripts/rotate-api-tokens.sh change-ft-account-passwords $STAGE
+          ''')
+        }
+        stage("Disable functional/smoke/smoulder tests") {
+          milestone()
+          waitUntil {
+            try {
+              input(message: "1/2: You should now temporarily disable the functional tests, smoke tests and smoulder tests for this stage")
+              input(message: "2/2: Have you definitely disabled the functional tests, smoke tests and smoulder tests for this stage? Great. Go ahead.")
+              return true
+            } catch(error) {
+              input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
+              return false
+            }
+          }
+          milestone()
+        }
+        stage("Merge credentials PR") {
+          milestone()
+          waitUntil {
+            try {
+              input(message: "1/2: Do not continue until the Pull Request updating FT account passwords has been merged to master.")
+              input(message: "2/2: Have you definitely merged the dm-credentials Pull Request? Great. Go ahead.")
+              return true
+            } catch(error) {
+              input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
+              return false
+            }
+          }
+          milestone()
+        }
+        stage("Update Jenkins Config") {
+          milestone()
+          waitUntil {
+            try {
+              input(message: "1/2: You should now prepare Jenkins for shutdown (Jenkins Homepage -> Manage Jenkins -> Prepare for Shutdown) and wait for all running jobs to finish. Then, you need to run `make jenkins TAGS=config` (with up-to-date DM_CREDENTIALS_REPO defined) to synchronize Jenkins' environment with the just-merged tokens. Jenkins will then restart.")
+              input(message: "2/2: Have you run `make jenkins TAGS=config` (with up-to-date DM_CREDENTIALS_REPO defined) and allowed Jenkins to restart? Great. Go ahead.")
+              return true
+            } catch(error) {
+              input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
+              return false
+            }
+          }
+          milestone()
+        }
+        stage("Synchronize passwords in dm-credentials with DMP") {
+          sh('''
+            docker run --rm \
+              -v /var/lib/jenkins/digitalmarketplace-credentials:/digitalmarketplace-credentials \
+              -v $HOME/.aws:/root/.aws \
+              -e DM_CREDENTIALS_REPO=/digitalmarketplace-credentials \
+              -e GITHUB_ACCESS_TOKEN \
+              digitalmarketplace/scripts \
+              scripts/rotate-api-tokens.sh sync-ft-account-passwords $STAGE
+          ''')
+        }
+        stage("Re-enable functional/smoke/smoulder tests") {
+          milestone()
+          waitUntil {
+            try {
+              input(message: "1/2: You haven't finished until you've re-enabled the functional tests, smoke tests and smoulder tests for this stage")
+              input(message: "2/2: Have you definitely re-enabled the functional tests, smoke tests and smoulder tests for this stage? Great. Go ahead.")
+              return true
+            } catch(error) {
+              input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")
+              return false
+            }
+          }
+          milestone()
+        }
+      }

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -187,6 +187,7 @@ jenkins_list_views:
       - update-credentials
       - rotate-api-tokens
       - rotate-production-notify-callback-token
+      - rotate-ft-account-passwords
       - virus-scan-s3-buckets-preview
       - virus-scan-s3-buckets-staging
       - virus-scan-s3-buckets-production


### PR DESCRIPTION
https://trello.com/c/AOxxcCSy

This is a fairly basic initial stab at this pipeline which we should probably discuss/flesh out.

The reason this is a bit of a tricky process is the time between merging the PR/restarting jenkins/syncing the passwords is a bit of a "critical section". We can't use a graceful switchover technique similar to the other token rotation scripts because DMP accounts don't support multiple passwords.

Really the best thing to do is disable the functional/smoke/smoulder tests during these phases then re-enable them. But should we hint at this strongly in the pipeline? Put _another_ "stop and do this" stage in?

It does actually look like it would be possible to disable jobs _from_ another job, so hypothetically we could do it all automatically... but do we dare get into that kind of stuff?