### PR TITLE
rotate-ft-account-passwords job: fix by adding update-credentials step and changing suggested ansible command

### DIFF
--- a/job_definitions/rotate_ft_account_passwords.yml
+++ b/job_definitions/rotate_ft_account_passwords.yml
@@ -51,12 +51,15 @@
           }
           milestone()
         }
-        stage("Update Jenkins Config") {
+        stage("Update Jenkins Credentials") {
+          build job: "update-credentials"
+        }
+        stage("Update Jenkins Jobs") {
           milestone()
           waitUntil {
             try {
-              input(message: "1/2: You should now prepare Jenkins for shutdown (Jenkins Homepage -> Manage Jenkins -> Prepare for Shutdown) and wait for all running jobs to finish. Then, you need to run `make jenkins TAGS=config` (with up-to-date DM_CREDENTIALS_REPO defined) to synchronize Jenkins' environment with the just-merged tokens. Jenkins will then restart.")
-              input(message: "2/2: Have you run `make jenkins TAGS=config` (with up-to-date DM_CREDENTIALS_REPO defined) and allowed Jenkins to restart? Great. Go ahead.")
+            input(message: "1/2: You should now re-push all Jenkins jobs by running `make jenkins TAGS=jobs` (with an up-to-date DM_CREDENTIALS_REPO defined) to synchronize embedded credentials in Jenkins' jobs with the just-merged tokens. Be careful to check whether there are any outstanding applied-but-unmerged jenkins job changes that people don't want overwritten.")
+              input(message: "2/2: Have you run `make jenkins TAGS=jobs` (with an up-to-date DM_CREDENTIALS_REPO defined)? Great. Go ahead.")
               return true
             } catch(error) {
               input(message: "If you *definitely* want to abandon this pipeline, click 'Abort' again. If not, click 'Proceed' to continue.")

--- a/job_definitions/rotate_ft_account_passwords.yml
+++ b/job_definitions/rotate_ft_account_passwords.yml
@@ -8,8 +8,10 @@
       - choice:
           name: STAGE
           choices:
-            - preview
-            - staging
+# this job does *work* for preview & staging, it's just probably not a good idea to change the expected passwords on preview & staging because
+# of the way the functional tests (at time of writing) expect to be able to log into arbitrary existing accounts with DM_<role>_USER_PASSWORD
+#            - preview
+#            - staging
             - production
     dsl: |
       currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE}"


### PR DESCRIPTION
https://trello.com/c/VKQKtzQW

Two things were wrong with the previous incarnation:

 - It prompted the user to do a `make jenkins TAGS=config` to update Jenkins' global environment variables. The problem is, the FT credentials aren't held in the global environment - they're in the job definitions themselves. So instead the user should be prompted to use `TAGS=jobs`.
 - It failed to update Jenkins' credentials repo before attempting to set the new passwords in the database, so ended up setting the existing ones.

The combination of these two problems however meant that everything continued to work and everything appeared to be fine... except the values now held in the credentials repo didn't reflect reality.