### PR TITLE
clean and apply db dump job: add functional test run before visual regression acceptance

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -180,6 +180,11 @@
 
 
 {% if environment in ['preview', 'staging'] %}
+              stage('Run functional tests') {
+                # running the functional tests should get the database in the right state for VR tests to produce identical results
+                build job: "functional-tests-{{ environment }}"
+              }
+
               stage('Run visual regression tests') {
                 run_visual_regression_tests("{{ environment }}")
               }


### PR DESCRIPTION
The functional tests make a few small changes to the state of the database which otherwise cause the newly-accepted visual regression result to fail as soon as the FTs are run after import.

I haven't tested this. Maybe I should.