### PR TITLE
Jenkins job for framework clarification question notification script

### DIFF
--- a/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
@@ -1,0 +1,52 @@
+{% set environments = ['preview', 'production'] %}
+{% set notify_template_id = 'ed9944eb-112e-4f04-a4bb-19f397550ffe' %}
+{% set framework_slug = 'g-cloud-12' %}
+---
+{% for environment in environments %}
+- job:
+    name: "notify-suppliers-of-framework-clarification-questions-answers-{{ environment }}"
+    display-name: "Notify suppliers of new framework clarification questions and answers - {{ environment }}"
+    project-type: freestyle
+    disabled: true
+    description: |
+      Send email notifications to supplier users about new framework clarification questions and answers.
+      This job is triggered manually, after a framework manager admin has uploaded a new set of clarification PDFs.
+    parameters:
+      - string:
+          name: RESUME_RUN_ID
+          description: "UUID of a previously failed run to use for resending (this will skip any users who were successfully emailed)"
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "List notifications that would be sent without sending the emails"
+    scm:
+      - git:
+          url: git@github.com:alphagov/digitalmarketplace-scripts.git
+          credentials-id: github_com_and_enterprise
+          branches:
+            - master
+          wipe-workspace: false
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=framework-question-and-answers
+              JOB=Notify suppliers of new framework clarification questions and answers {{ environment }}
+              ICON=:frame_with_picture:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-2ndline
+    builders:
+      - shell: |
+          if [ -n "RESUME_RUN_ID" ]; then
+            FLAGS="--resume-run-id=RESUME_RUN_ID"
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-fw-cq-answers.py {{ environment }} {{ framework_slug }} $NOTIFY_API_TOKEN {{ notify_template_id }} $FLAGS
+{% endfor %}

--- a/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
@@ -1,6 +1,6 @@
 {% set environments = ['preview', 'production'] %}
 {% set notify_template_id = 'ed9944eb-112e-4f04-a4bb-19f397550ffe' %}
-{% set framework_slug = 'g-cloud-12' %}
+{% set default_framework_slug = 'g-cloud-12' %}
 ---
 {% for environment in environments %}
 - job:
@@ -15,6 +15,10 @@
       - string:
           name: RESUME_RUN_ID
           description: "UUID of a previously failed run to use for resending (this will skip any users who were successfully emailed)"
+      - string:
+          name: FRAMEWORK_SLUG
+          default: {{ default_framework_slug }}
+          description: "Framework to send notifications about, e.g. 'g-cloud-12'. Must have status 'open' or the script will fail."
       - bool:
           name: DRY_RUN
           default: false
@@ -48,5 +52,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-fw-cq-answers.py {{ environment }} {{ framework_slug }} $NOTIFY_API_TOKEN {{ notify_template_id }} $FLAGS
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-fw-cq-answers.py {{ environment }} $FRAMEWORK_SLUG $NOTIFY_API_TOKEN {{ notify_template_id }} $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
@@ -40,8 +40,8 @@
               CHANNEL=#dm-2ndline
     builders:
       - shell: |
-          if [ -n "RESUME_RUN_ID" ]; then
-            FLAGS="--resume-run-id=RESUME_RUN_ID"
+          if [ -n "$RESUME_RUN_ID" ]; then
+            FLAGS="--resume-run-id=$RESUME_RUN_ID"
           fi
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
@@ -36,7 +36,7 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=framework-question-and-answers
-              JOB=Notify suppliers of new framework clarification questions and answers {{ environment }}
+              JOB=Notify suppliers of new ${FRAMEWORK_SLUG} clarification questions and answers {{ environment }}
               ICON=:frame_with_picture:
               STAGE={{ environment }}
               STATUS=FAILED

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -214,6 +214,7 @@ jenkins_list_views:
       - mark-definite-framework-results-preview
       - mark-definite-framework-results-production
       - notify-suppliers-whether-application-made-for-framework-production
+      - notify-suppliers-of-framework-clarification-questions-answers-production
       - scan-g-cloud-services-for-bad-words
       - stats-performance-platform-digital-outcomes-and-specialists-4-per-hour-production
       - stats-performance-platform-digital-outcomes-and-specialists-4-per-day-production


### PR DESCRIPTION
https://trello.com/c/xbqxyfNV/210-notify-suppliers-about-new-framework-clarification-questions-via-the-admin

Job for running the new framework clarification question email script: https://github.com/alphagov/digitalmarketplace-scripts/pull/459.

Assumes that the job will be manually triggered for now. We can update the job later if we introduce any sort of S3/etag hook.

I've hardcoded some settings for the time being:
- Set `disabled` to True for now as well (we can enable it once the framework opens)
- Included `preview` environment for testing purposes (to be removed later, so I've only included the production job in the listings)
- Set `framework_slug` to `g-cloud-12`. We're only going to set this once per framework - having to type it in as a parameter on each run would be tedious, and it's very unlikely that our service will have multiple frameworks open at once in the near future.