### PR TITLE
Failure notifications should go to dm-release slack channel

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -99,7 +99,7 @@
                 sh('make run-postgres-container')
               }
 
-              stage('Import and clean lastest production db-dump') {
+              stage('Import and clean latest production db-dump') {
                 sh(
                   script: '''
                     make requirements

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -50,13 +50,13 @@
         }
       }
 
-      def notify_slack(icon, status, channel = "#dm-release") {
+      def notify_slack(icon, status) {
         build job: "notify-slack",
         parameters: [
           string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
-          string(name: 'CHANNEL', value: channel),
+          string(name: 'CHANNEL', value: "#dm-release"),
           text(name: 'STAGE', value: "{{ environment }}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
@@ -114,7 +114,7 @@
               }
 
               stage('Apply data to target stage and s3') {
-                notify_slack(':building_blue:', 'APPROVED', "#dm-release")
+                notify_slack(':building_blue:', 'APPROVED')
                 sh(
                    script: '''
                      export TARGET="{{ environment }}"
@@ -193,7 +193,7 @@
               notify_slack(':shower:', 'SUCCESS')
 
             } catch(err) {
-              notify_slack(':sadparrot:', 'FAILED', "#dm-2ndline")
+              notify_slack(':sadparrot:', 'FAILED')
               echo "Error caught"
               currentBuild.result = 'FAILURE'
               echo "Error: ${err}"

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -53,7 +53,7 @@
       def notify_slack(icon, status) {
         build job: "notify-slack",
         parameters: [
-          string(name: 'USERNAME', value: "clean-prod-db-dump-and-apply"),
+          string(name: 'USERNAME', value: "clean-and-apply-db-dump"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
           string(name: 'CHANNEL', value: "#dm-release"),


### PR DESCRIPTION
https://trello.com/c/OqGRNVi0/1373-preview-db-clean-failure-alert-should-go-to-dm-release

Failure alerts should only appear in the dm-2ndline channel for production environments. Therefore we can hardcode the `CHANNEL` value to `dm-release` for this job (it was already the default).

The `clean_and_apply_db_dump` job is never run *against* production, it just fetches prod data from S3 and sanitises it, ready to be loaded on preview/staging. I've changed the Slack alert 'username' to make this clearer.