### PR TITLE
Replace DOS3 email job with DOS4 job

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -163,7 +163,7 @@ jenkins_list_views:
       - notify-suppliers-of-dos-opportunities-production
       - notify-suppliers-of-new-questions-answers-production
       - notify-suppliers-of-brief-withdrawals-production
-      - upload-dos3-opportunities-email-list-production
+      - upload-dos4-opportunities-email-list-production
   - name: "Utils and toolkit"
     jobs:
       - build-image


### PR DESCRIPTION
The DOS4 job had a recent failure, I noticed that the DOS3 version was still showing on 'Emails' tab on Jenkins.

Jenkins will need to be updated with `make jenkins TAGS=config` for the changes to show up.