### PR TITLE
Add upper limit on number of builds to keep for tests

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -18,7 +18,6 @@
     properties:
       - build-discarder:
           days-to-keep: 60
-          artifact-days-to-keep: 60
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -18,6 +18,7 @@
     properties:
       - build-discarder:
           days-to-keep: 60
+          num-to-keep: 100
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -41,6 +41,7 @@
     properties:
       - build-discarder:
           days-to-keep: 30
+          num-to-keep: 100
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -41,7 +41,6 @@
     properties:
       - build-discarder:
           days-to-keep: 30
-          artifact-days-to-keep: 30
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -9,8 +9,6 @@
       - build-discarder:
           days-to-keep: 14
           num-to-keep: 50
-          artifact-days-to-keep: 14
-          artifact-num-to-keep: 50
     parameters:
       - choice:
           name: COMMAND


### PR DESCRIPTION
Ticket: https://trello.com/c/S34lzHqc/1415-is-jenkins-deleting-old-stuff-as-expected

We've had issues where we've run out of space on the Jenkins data volume due to a large number of test runs being retained. This seems to be because a large number of test runs took place in a short amount of time. We have a limit on the number of days we keep logs and artifacts for test runs, but not on the total number kept.

This commit adds a limit on the total number of builds retained for functional test and visual regression test jobs; this should help reduce the likelihood of running out of disk space in future.

I'm not totally wedded to these numbers; feel free to discuss ;)