### PR TITLE
Remove use of sops-wrapper from Jenkins jobs

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -59,7 +59,7 @@
                   sh("docker tag digitalmarketplace/${REPOSITORY} digitalmarketplace/${REPOSITORY}:${RELEASE_NAME}")
               }
               stage('Upload') {
-                  docker_credentials = sh(script: '/var/lib/jenkins/digitalmarketplace-credentials/sops-wrapper -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
+                  docker_credentials = sh(script: 'sops -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
                   withEnv(docker_credentials.tokenize("\n")) {
                       sh("set +x; docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
                   }

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -77,7 +77,7 @@
               build job: "update-credentials"
 
 {% if environment in ['preview', 'staging'] %}
-                paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+                paas_credentials = sh(script: 'sops -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
                 withEnv(paas_credentials.tokenize("\n")) {
                   sh('make paas-login')
                 }

--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -42,7 +42,7 @@
               echo "Getting ready to create ${DUMP_FILE_NAME}"
               git url: 'git@github.com:alphagov/digitalmarketplace-aws.git', branch: 'master', credentialsId: 'github_com_and_enterprise'
               build job: "update-credentials"
-              paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+              paas_credentials = sh(script: 'sops -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
               withEnv(paas_credentials.tokenize("\n")) {
                 sh('make paas-login')
               }

--- a/job_definitions/database_migration_paas.yml
+++ b/job_definitions/database_migration_paas.yml
@@ -49,7 +49,7 @@
 
               stage('Run database migration') {
                 withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
-                  paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+                  paas_credentials = sh(script: 'sops -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
                   withEnv(paas_credentials.tokenize("\n")) {
                       sh('make paas-login')
                   }

--- a/job_definitions/docker_base_images.yml
+++ b/job_definitions/docker_base_images.yml
@@ -34,7 +34,7 @@
             sh("make build")
           }
           stage('Push') {
-            docker_credentials = sh(script: '/var/lib/jenkins/digitalmarketplace-credentials/sops-wrapper -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
+            docker_credentials = sh(script: 'sops -d /var/lib/jenkins/digitalmarketplace-credentials/jenkins-vars/docker_credentials_env.enc', returnStdout: true).trim()
             withEnv(docker_credentials.tokenize("\n")) {
               sh("set +x; docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
             }

--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -51,7 +51,7 @@
 
           stage('Deploy') {
             withEnv(["DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials", "CF_HOME=${pwd()}"]) {
-              paas_credentials = sh(script: '$DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
+              paas_credentials = sh(script: 'sops -d $DM_CREDENTIALS_REPO/jenkins-vars/paas_credentials_env.enc', returnStdout: true).trim()
               withEnv(paas_credentials.tokenize("\n")) {
                 sh('make paas-login')
               }


### PR DESCRIPTION
Looking at the [sops-wrapper] and [aws-auth] scripts, I've come to the conclusion that these scripts are a no-op on Jenkins; i.e. they run the `sops` command without modifying the environment as they would do on a developer machine.

I've tested this theory out by running the sops command as the ubuntu user while SSHed into the Jenkins box, and by manually updating the docker-base-images pipeline in Jenkins and running it. Both tests succeeded.

I think this means we can deprecate use of sops-wrapper and aws-auth on Jenkins, and look at removing it.

This PR is just the first step, removing uses of sops-wrapper (which calls aws-auth) from our job definitions. I didn't find any uses of aws-auth in our job definitions.

It may not be as easy to remove these scripts completely as some commands will be designed to run on both Jenkins and developer machines, but this is a start!

[aws-auth]: https://github.com/alphagov/aws-auth/blob/master/aws-auth.sh
[sops-wrapper]: https://github.com/alphagov/digitalmarketplace-credentials/blob/master/sops-wrapper