### PR TITLE
Add random password for PostgreSQL container

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -69,7 +69,8 @@
         withEnv([
           "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials",
           "CF_HOME=${pwd()}",
-          "PAAS_SPACE={{ environment }}"
+          "PAAS_SPACE={{ environment }}",
+          "POSTGRES_NAME=dm_db_clean_{{ environment }}",
         ]) {
           try {
             stage('Prepare') {
@@ -93,6 +94,10 @@
                 ).trim()
 {% endif %}
 
+                // Generate a random password for PostgreSQL container
+                postgres_password = sh(script: 'openssl rand -base64 32', returnStdout:true).trim()
+                env.POSTGRES_PASSWORD = postgres_password
+                env.PGPASSWORD = postgres_password
               }
 
               stage('Run postgres container') {


### PR DESCRIPTION
Ticket: https://trello.com/c/VBYabYVZ/1436-db-restore-on-staging-failed

Our clean_and_apply_db_dump job on Jenkins has stopped working because the postgres Docker image expects an environment variable POSTGRES_PASSWORD.

This commit adds a command to the prepare step to generate a random password and adds it to the environment. We also set PGPASSWORD in the environment for the psql command.

Depends on alphagov/digitalmarketplace-aws#628