### PR TITLE
BAU - Better and more regular pruning of docker images on Jenkins

### DIFF
--- a/job_definitions/clean_docker_images.yml
+++ b/job_definitions/clean_docker_images.yml
@@ -16,6 +16,6 @@
             fi
           done
 
-          docker image prune -f
+          docker image prune -af
     triggers:
-      - timed: "H H * * 0"
+      - timed: "H H * * *"


### PR DESCRIPTION
**Ticket:** https://trello.com/c/ycDYRwvi/1428-jenkins-data-volume-low-on-disk-space-again

- prune all docker images without at least one container associated to them,
  not just dangling ones
- run cleaning task once a day, instead of weekly, to account for days where we
  have an uncommon peak usage of Jenkins

We sometimes run low on disk space during periods of peak usage of Jenkins. An investigation spotted that pruning all docker images not in use freed up 28G.

See discussion on https://trello.com/c/ycDYRwvi/1428-jenkins-data-volume-low-on-disk-space-again

Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>