### PR TITLE
Retain smoke/smoulder test history for 1000 jobs

### DIFF
--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -41,7 +41,7 @@
     properties:
       - build-discarder:
           days-to-keep: 30
-          num-to-keep: 100
+          num-to-keep: 1000
     parameters:
       - string:
           name: FT_BRANCH_NAME


### PR DESCRIPTION
https://trello.com/c/0v7YcHE2/1463-ensure-builds-kept-for-at-least-2-days

12 jobs per hour x 24 hours x 3 days = 864 jobs (rounded up to 1000)

This should cover weekends and bank holidays.