### PR TITLE
Export G12 supplier data to S3 for use in admin

### DIFF
--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -1,6 +1,6 @@
 {% set environments = ['preview', 'staging', 'production'] %}
 {% set frameworks = [
-    'g-cloud-9', 'g-cloud-10', 'g-cloud-11',
+    'g-cloud-9', 'g-cloud-10', 'g-cloud-11', 'g-cloud-12',
     'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3', 'digital-outcomes-and-specialists-4'
   ]
 %}


### PR DESCRIPTION
https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html#id9

Adds the new G12 framework to the overnight supplier export job. This will make supplier data available in S3 (and accessible by framework manager admins), in case we need to manually contact all suppliers who've started a framework application.