### PR TITLE
Revert "Work around for jenkins_plugin module bug"

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -13,12 +13,7 @@ jenkins_connection_retries: 60
 jenkins_domain_name: marketplace.team
 jenkins_server_name: "{{ inventory_hostname | regex_replace('^(.*)' + jenkins_domain_name, '\\1') }}"
 jenkins_hostname: localhost
-# When performing a fresh install of Jenkins server 2.194 we are seeing the error described here:
-# https://stackoverflow.com/questions/57724934/ansible-jenkins-plugin-module-returns-http-error-403-no-valid-crumb-was-includ
-# https://stackoverflow.com/questions/57731818/jenkins-2-192-http-error-403-no-valid-crumb-was-included-in-the-request
-# https://github.com/ansible/ansible/issues/61712
-# Manifests as `HTTP Error 403: No valid crumb was included in the request` error from `jenkins_plugins` Ansible directive
-jenkins_java_args: "-Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true"
+jenkins_java_args: ""
 
 jobs: '*'
 jobs_disabled: false

--- a/playbooks/roles/jenkins/tasks/06_plugins.yml
+++ b/playbooks/roles/jenkins/tasks/06_plugins.yml
@@ -28,11 +28,11 @@
 
 - name: Install plugins
   jenkins_plugin:
+    jenkins_home: "{{ jenkins_data_dir }}"
     name: "{{ item }}"
     url_username: "{{ plugins_username }}"
     url_password: "{{ plugins_password }}"
   with_items: "{{ jenkins_plugins }}"
-
 
 - name: Restart Jenkins to activate new plugins
   service: name=jenkins state=restarted

--- a/playbooks/roles/jenkins/templates/jenkins_defaults.j2
+++ b/playbooks/roles/jenkins/templates/jenkins_defaults.j2
@@ -17,13 +17,6 @@ JAVA_ARGS="${JAVA_ARGS} -Dhudson.model.DirectoryBrowserSupport.CSP=\"sandbox all
 # A comment on that page suggests that setting this property to false should be a temporary work-around to avoid getting the error
 JAVA_ARGS="${JAVA_ARGS} -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false"
 
-# When performing a fresh install of Jenkins server 2.194 we are seeing the error described here:
-# https://stackoverflow.com/questions/57724934/ansible-jenkins-plugin-module-returns-http-error-403-no-valid-crumb-was-includ
-# https://stackoverflow.com/questions/57731818/jenkins-2-192-http-error-403-no-valid-crumb-was-included-in-the-request
-# https://github.com/ansible/ansible/issues/61712
-# Manifests as `HTTP Error 403: No valid crumb was included in the request` error from `jenkins_plugins` Ansible directive
-JAVA_ARGS="${JAVA_ARGS} -Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true"
-
 PIDFILE=/var/run/jenkins/jenkins.pid
 
 # user id to be invoked as (otherwise will run as root; not wise!)


### PR DESCRIPTION
This reverts commit 0ab15b94b53b19ea3b3e115af45b36da1b2ce458.

Closes https://trello.com/c/Ne3rA9In/

### Applying

This will need to be applied by running `make jenkins TAGS=jenkins` and restarting the Jenkins EC2 instance.

### Testing

We can then test it worked by running `make jenkins TAGS=plugins` and making sure we get no errors from the `jenkins_plugin` steps.