### PR TITLE
Jenkins job for 1-week reminder script

### DIFF
--- a/job_definitions/notify_suppliers_with_incomplete_applications.yml
+++ b/job_definitions/notify_suppliers_with_incomplete_applications.yml
@@ -44,6 +44,11 @@
           if [ "$DRY_RUN" = "true" ]; then
             FLAGS="--dry-run"
           fi
-
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} scripts/notify-suppliers-with-incomplete-applications.py  {{ environment }} $FRAMEWORK_SLUG $NOTIFY_API_TOKEN $FLAGS
+          docker run -e \
+            DM_DATA_API_TOKEN_{{ environment|upper }} \
+            digitalmarketplace/scripts scripts/notify-suppliers-with-incomplete-applications.py \
+            '{{ environment }}' \
+            $FRAMEWORK_SLUG \
+            $NOTIFY_API_TOKEN \
+            $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_with_incomplete_applications.yml
+++ b/job_definitions/notify_suppliers_with_incomplete_applications.yml
@@ -1,0 +1,49 @@
+{% set environments = ['preview', 'production'] %}
+{% set default_framework_slug = 'g-cloud-12' %}
+---
+{% for environment in environments %}
+- job:
+    name: "notify-suppliers-with-incomplete-applications-{{ environment }}"
+    display-name: "Notify suppliers with incomplete applications - {{ environment }}"
+    project-type: freestyle
+    disabled: true
+    description: |
+      Send email notifications to supplier users who have not completed 1 or more parts of their framework applications.
+      This job is triggered manually and is usually sent 1 week prior to the application deadline.
+      The Notify template ID is currently hardcoded into the script.
+    parameters:
+      - string:
+          name: FRAMEWORK_SLUG
+          default: {{ default_framework_slug }}
+          description: "Framework to send notifications about, e.g. 'g-cloud-12'. Must have status 'open' or the script will fail."
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "List notifications that would be sent without sending the emails"
+    scm:
+      - git:
+          url: git@github.com:alphagov/digitalmarketplace-scripts.git
+          credentials-id: github_com_and_enterprise
+          branches:
+            - master
+          wipe-workspace: false
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=framework-incomplete-applications
+              JOB=Notify suppliers with incomplete ${FRAMEWORK_SLUG} applications {{ environment }}
+              ICON=:trident:
+              STAGE={{ environment }}
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-2ndline
+    builders:
+      - shell: |
+          if [ "$DRY_RUN" = "true" ]; then
+            FLAGS="--dry-run"
+          fi
+
+          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} scripts/notify-suppliers-with-incomplete-applications.py  {{ environment }} $FRAMEWORK_SLUG $NOTIFY_API_TOKEN $FLAGS
+{% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -210,6 +210,8 @@ jenkins_list_views:
       - mark-definite-framework-results-production
       - notify-suppliers-whether-application-made-for-framework-production
       - notify-suppliers-of-framework-clarification-questions-answers-production
+      - notify-suppliers-of-framework-application-event-production
+      - notify-suppliers-with-incomplete-applications-production
       - scan-g-cloud-services-for-bad-words
       - stats-performance-platform-digital-outcomes-and-specialists-4-per-hour-production
       - stats-performance-platform-digital-outcomes-and-specialists-4-per-day-production


### PR DESCRIPTION
https://trello.com/c/40Uz1at0/355-jenkinsify-the-1-week-reminder-script-2

Creates a separate job for an existing script, which sends emails to suppliers with incomplete framework applications 1 week before the application deadline.

The script hardcodes the Notify template ID so we don't need to include it in the Jenkins job for now.