### PR TITLE
Add success notification to manually triggered framework email jobs

### DIFF
--- a/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_framework_clarification_questions_answers.yml
@@ -36,12 +36,22 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=framework-question-and-answers
-              JOB=Notify suppliers of new ${FRAMEWORK_SLUG} clarification questions and answers {{ environment }}
+              JOB=Notify suppliers of new ${FRAMEWORK_SLUG} clarification questions and answers - {{ environment }}
               ICON=:frame_with_picture:
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-2ndline
+          - project: notify-slack
+            condition: SUCCESS
+            predefined-parameters: |
+              USERNAME=framework-question-and-answers
+              JOB=Notify suppliers of new ${FRAMEWORK_SLUG} clarification questions and answers - {{ environment }}
+              ICON=:thinkies:
+              STAGE={{ environment }}
+              STATUS=SUCCESS
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
     builders:
       - shell: |
           if [ -n "$RESUME_RUN_ID" ]; then

--- a/job_definitions/notify_suppliers_with_incomplete_applications.yml
+++ b/job_definitions/notify_suppliers_with_incomplete_applications.yml
@@ -33,12 +33,22 @@
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
               USERNAME=framework-incomplete-applications
-              JOB=Notify suppliers with incomplete ${FRAMEWORK_SLUG} applications {{ environment }}
+              JOB=Notify suppliers with incomplete ${FRAMEWORK_SLUG} applications - {{ environment }}
               ICON=:trident:
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
               CHANNEL=#dm-2ndline
+          - project: notify-slack
+            condition: SUCCESS
+            predefined-parameters: |
+              USERNAME=framework-incomplete-applications
+              JOB=Notify suppliers with incomplete ${FRAMEWORK_SLUG} applications - {{ environment }}
+              ICON=:star2:
+              STAGE={{ environment }}
+              STATUS=SUCCESS
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-release
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
It would be nice to get a message in Slack letting us know when the email job has finished, especially for the long running ones.

---

I've done

- Clarification questions email job
- Incomplete framework applications email job

What other jobs should we add success notifications to?