### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+# Dependabot config
+# https://dependabot.com/docs/config-file/
+# Checks and updates dependencies in
+# `requirements.txt`
+
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
https://trello.com/c/4ePZUeMK/1336-move-apps-tools-from-pyup-to-dependabot

Trying out dependabot on the Jenkins repo. I'm not sure if it will pick up `requirements-jenkins-job-builder.txt` as well as `requirements.txt`.