### PR TITLE
Remove build discarder from daily framework stats snapshots

### DIFF
--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -65,10 +65,6 @@
     project-type: pipeline
     triggers:
       - timed: "H 23 * * *"
-    properties:
-      - build-discarder:
-          days-to-keep: 20
-          artifact-days-to-keep: 20
     description: |
       <p>Daily export of application statistics to Google Drive. Also logs to audit event.</p>
     dsl: |


### PR DESCRIPTION
I found myself thwarted just now because our G-Cloud 11 stats from the beginning of the framework are gone.

It's useful being able to go back and look at the old stats snapshots, and they don't take up much space, so this commit removes the build discarder from the daily stats snapshot job.

This won't bring back the old stuff, but it may reduce frustration in the future :)