### PR TITLE
Allow AWS CLI to switch infrastructure roles

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -56,6 +56,7 @@
   become_user: jenkins
   vars:
     assume_cloudtrail_roles: "{{ cloudtrail_validate_logs_roles }}"
+    assume_infrastructure_roles: "{{ aws_infrastructure_roles }}"
 
 - name: Install rbenv
   git: repo={{ item.repo }} dest=/var/lib/jenkins/{{ item.path }}

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -55,7 +55,7 @@
   become: true
   become_user: jenkins
   vars:
-    assume_roles: "{{ cloudtrail_validate_logs_roles }}"
+    assume_cloudtrail_roles: "{{ cloudtrail_validate_logs_roles }}"
 
 - name: Install rbenv
   git: repo={{ item.repo }} dest=/var/lib/jenkins/{{ item.path }}

--- a/playbooks/roles/jenkins/templates/aws_config.j2
+++ b/playbooks/roles/jenkins/templates/aws_config.j2
@@ -1,3 +1,5 @@
+[default]
+region=eu-west-1
 {% for role in assume_cloudtrail_roles %}
 
 [profile {{role.profile.name}}]

--- a/playbooks/roles/jenkins/templates/aws_config.j2
+++ b/playbooks/roles/jenkins/templates/aws_config.j2
@@ -5,3 +5,9 @@ credential_source=Ec2InstanceMetadata
 region={{role.profile.region}}
 role_arn={{role.profile.role_arn}}
 {% endfor %}
+{% for role in aws_infrastructure_roles %}
+
+[profile {{role.profile.name}}]
+credential_source=Ec2InstanceMetadata
+role_arn={{role.profile.role_arn}}
+{% endfor %}

--- a/playbooks/roles/jenkins/templates/aws_config.j2
+++ b/playbooks/roles/jenkins/templates/aws_config.j2
@@ -1,4 +1,4 @@
-{% for role in assume_roles %}
+{% for role in assume_cloudtrail_roles %}
 
 [profile {{role.profile.name}}]
 credential_source=Ec2InstanceMetadata


### PR DESCRIPTION
https://trello.com/c/kCUjDnH4/48-3-3-jenkins-job-for-publish-services

The Jenkins user already has permission to assume the infrastructure roles, but the AWS CLI client needs to be configured on the Jenkins instance to actually do it.

The variables `cloudtrail_validate_logs_roles` and `aws_infrastructure_roles` are extracted from the credentials repo [when the Ansible playbook is initialised](https://github.com/alphagov/digitalmarketplace-jenkins/blob/master/Makefile#L50).  As such, the [PR to add the new var](https://github.com/alphagov/digitalmarketplace-credentials/pull/321) will need to be merged before this one. 