### PR TITLE
Downgrade Ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install:
+  - make requirements
+script:
+  - make requirements-dev
+notifications:
+  email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.9.10
+ansible==2.9.9


### PR DESCRIPTION
Snyk overeagerly upgrade Ansible for us - [the version is no longer available to download](https://pypi.org/project/ansible/#history). Let's revert back to the previous version.

To prevent this happening again, I've added a Travis config file to try and install the requirements before merging.