### PR TITLE
Enforce AWS_PROFILE choices on publish-draft-services

### DIFF
--- a/job_definitions/publish_draft_services.yml
+++ b/job_definitions/publish_draft_services.yml
@@ -21,10 +21,17 @@
       - string:
           name: FRAMEWORK_SLUG
           description: "The framework slug to publish services for, e.g. 'g-cloud-11'."
-      - string:
+      - choice:
           name: AWS_PROFILE
-          default: "{% if environment == 'production' %}production{% else %}development{% endif %}"
-          description: "AWS profile to copy documents as. Only used for G-Cloud frameworks."
+          choices:
+{% if environment == 'production' %}
+            - production
+            - development
+{% else %}
+            - development
+            - production
+{% endif %}
+          description: "AWS profile to copy documents as. Only used for G-Cloud frameworks - either value can be entered for DOS frameworks."
       - bool:
           name: SKIP_DOCS_IF_PUBLISHED
           default: false


### PR DESCRIPTION
https://trello.com/c/ui2WdVFw/148-05-make-publish-draft-services-jenkins-job-dos-friendly

I did a quick local test for DOS, and while the AWS_PROFILE isn't needed for that framework, if a malformed value is provided (e.g. `bananas-infrastructure`) then the script will fail. So I've enforced the available values as choices on the job and clarified that either value can be used for DOS.