### PR TITLE
fix double encoding of template-id

### DIFF
--- a/job_definitions/notify_suppliers_of_framework_application_events.yml
+++ b/job_definitions/notify_suppliers_of_framework_application_events.yml
@@ -81,7 +81,7 @@
           fi
 
           NOTIFY_TEMPLATE_MAP='{{ notify_template_map | to_json }}'
-          NOTIFY_TEMPLATE_ID="$(echo $NOTIFY_TEMPLATE_MAP | jq '.[env.EMAIL_TYPE]')"
+          NOTIFY_TEMPLATE_ID="$(echo $NOTIFY_TEMPLATE_MAP | jq --raw-output '.[env.EMAIL_TYPE]')"
 
           docker run -e \
             "DM_DATA_API_TOKEN_{{ environment|upper }}" \


### PR DESCRIPTION
jenkins job was failing with:
```
ERROR Failed sending to 1mF_4Gmg0MmIHqpmBvBax9dfnCBexXPouui3QQdxUNA=: 400 - [{'error': 'ValidationError', 'message': 'template_id is not a valid UUID'}]
```
it appears this is because the template-id is being double quote encoded e.g.
```
'"119dde9a-1e44-4b1d-9224-2f7020a74f9f"'
```
Using this argument should cause only the raw string to be outputted by jq.