### PR TITLE
Allow Jenkins to scan draft services for bad words

### DIFF
--- a/job_definitions/scan_g_cloud_services_for_bad_words.yml
+++ b/job_definitions/scan_g_cloud_services_for_bad_words.yml
@@ -5,7 +5,11 @@
     name: "scan-g-cloud-services-for-bad-words-{{ environment }}"
     display-name: "Scan G-Cloud services for bad words - {{ environment }}"
     project-type: pipeline
-    description: "Scans G-Cloud services for bad words contained in a list in our bad words repo."
+    description: |
+      Scans G-Cloud services for bad words contained in a list in our bad words repo.
+      Select 'draft' Service Type to scan draft services. Only suppliers marked as 'onFramework' in the DB will have
+      their services scanned, so make sure the 'mark-definite-framework-results' script has been run before scanning
+      drafts.
     parameters:
       - string:
           name: FRAMEWORK

--- a/job_definitions/scan_g_cloud_services_for_bad_words.yml
+++ b/job_definitions/scan_g_cloud_services_for_bad_words.yml
@@ -10,6 +10,11 @@
       - string:
           name: FRAMEWORK
           description: "Slug of framework to scan for bad words"
+      - choice:
+          name: SERVICE_TYPE
+          choices:
+            - 'live'
+            - 'draft'
     dsl: |
       def notify_slack(status) {
         build job: "notify-slack",
@@ -41,6 +46,10 @@
           }
           stage('Run bad words script') {
             sh('''
+              if [ "$SERVICE_TYPE" = "draft" ]; then
+                FLAGS="--scan-drafts"
+              fi
+
               docker run \
                 -e DM_DATA_API_TOKEN_{{ environment|upper }} \
                 --volume \$(pwd)/data:/app/data digitalmarketplace/scripts \
@@ -49,7 +58,8 @@
                 /app/data/digitalmarketplace-frameworks \
                 /app/data/digitalmarketplace-bad-words/blacklist.txt \
                 $FRAMEWORK \
-                /app/data
+                /app/data \
+                $FLAGS
             ''')
           }
           stage('Publish report') {


### PR DESCRIPTION
Preparing for close of G12 applications: https://trello.com/c/r2tU2OcI.

The `scan-g-cloud-services-for-bad-words.py` script already accepts a `--scan-drafts` parameter, but the current Jenkins job doesn't have the option to include it. 

The job can take a while, so it'd be good to run it on Jenkins rather than a developer laptop (even if the output file is slightly trickier to access!).