### PR TITLE
Tidy jobs tabs

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -208,7 +208,7 @@ jenkins_list_views:
       - notify-suppliers-whether-application-made-for-framework-production
       - notify-suppliers-of-framework-application-event-production
       - notify-suppliers-with-incomplete-applications-production
-      - scan-g-cloud-services-for-bad-words
+      - scan-g-cloud-services-for-bad-words-production
       - hourly-stats-snapshot-g-cloud-12-production
       - daily-stats-snapshot-g-cloud-12-production
   - name: "Code backups"

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -203,7 +203,6 @@ jenkins_list_views:
   - name: "Framework lifecycle jobs"
     jobs:
       - generate-upload-and-notify-counterpart-signature-pages-production
-      - mark-definite-framework-results-preview
       - mark-definite-framework-results-production
       - notify-suppliers-whether-application-made-for-framework-production
       - notify-suppliers-of-framework-application-event-production

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -207,6 +207,7 @@ jenkins_list_views:
       - notify-suppliers-whether-application-made-for-framework-production
       - notify-suppliers-of-framework-application-event-production
       - notify-suppliers-with-incomplete-applications-production
+      - publish-draft-services-production
       - scan-g-cloud-services-for-bad-words-production
       - hourly-stats-snapshot-g-cloud-12-production
       - daily-stats-snapshot-g-cloud-12-production

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -209,9 +209,8 @@ jenkins_list_views:
       - notify-suppliers-of-framework-application-event-production
       - notify-suppliers-with-incomplete-applications-production
       - scan-g-cloud-services-for-bad-words
-      - stats-performance-platform-digital-outcomes-and-specialists-4-per-hour-production
-      - stats-performance-platform-digital-outcomes-and-specialists-4-per-day-production
-      - stats-snapshot-g-cloud-12-production
+      - hourly-stats-snapshot-g-cloud-12-production
+      - daily-stats-snapshot-g-cloud-12-production
   - name: "Code backups"
     jobs:
       - backup-digitalmarketplace-admin-frontend

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -147,7 +147,7 @@ jenkins_list_views:
       - functional-tests-staging
       - visual-regression-preview
       - visual-regression-staging
-  - name: "Emails"
+  - name: "DOS Emails"
     jobs:
       - notify-buyers-to-award-closed-briefs-4-weeks-production
       - notify-buyers-to-award-closed-briefs-8-weeks-production


### PR DESCRIPTION
https://trello.com/c/k3m1QpwJ/1390-clean-up-jenkins-job-tabs

- Rename the 'Emails' tab to 'DOS Emails', as these are regular (daily) emails that are only relate to DOS opportunities, and have nothing to do with the framework lifecycle. I kept the name short on purpose - if folks prefer 'Daily DOS Emails' I can change? 
- Fixes some jobs which had been renamed at some point, and didn't match up with the name in the config
- Removes the `preview` version of the 'mark definite framework results' job, to reduce clutter (it's still there on the 'All' tab)
- Adds in the new(ish) `publish-draft-services` job