### PR TITLE
Update mark-definite-framework-results to log Jenkins user in audit logs

### DIFF
--- a/job_definitions/mark_definite_framework_results.yml
+++ b/job_definitions/mark_definite_framework_results.yml
@@ -44,11 +44,21 @@
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>
               CHANNEL=#dm-release
+    wrappers:
+      - build-user-vars
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/framework-applications/mark-definite-framework-results.py '{{ environment }}' "${FRAMEWORK_SLUG}" "${PASS_SCHEMA}" $FLAGS
+          docker run \
+            -e DM_DATA_API_TOKEN_{{ environment|upper }} \
+            digitalmarketplace/scripts \
+              scripts/framework-applications/mark-definite-framework-results.py \
+                '{{ environment }}' \
+                "${FRAMEWORK_SLUG}" \
+                "${PASS_SCHEMA}" \
+                --updated-by="${BUILD_TAG} started by ${BUILD_USER}" \
+                $FLAGS
 {% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -60,6 +60,7 @@ jenkins_plugins:
   - audit-trail
   - build-monitor-plugin
   - build-name-setter
+  - build-user-vars-plugin
   - conditional-buildstep
   - cvs
   - extended-choice-parameter


### PR DESCRIPTION
We want the Jenkins user who starts the mark-definite-framework-results to be recorded in our audit log, so we can see later who made a change.

By default the mark-definite-framework-results script uses the unix username, which on Jenkins is not very useful. Instead we use the build tag and build user envvars from the [build user vars plugin](https://plugins.jenkins.io/build-user-vars-plugin/) to make a more useful message.