### PR TITLE
Add system dependencies for new counterpart signature PDF script

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -35,6 +35,7 @@ dist_tools:
   - python3-dev
   - python3-pip
   - python3-venv
+  - ttf-mscorefonts-installer
   - unzip
   - xvfb
   - zip

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -4,6 +4,10 @@
   notify:
     - restart jenkins
 
+- name: Accept Microsoft core fonts EULA
+  tags: [apt]
+  shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
+
 - name: Install tools
   tags: [apt]
   apt:
@@ -19,10 +23,15 @@
     update_cache: yes
     state: present
     name:
-      - wkhtmltopdf=0.12.*
       - jq=1.5+dfsg-*
       - nodejs=8.*
       - libssl1.0-dev
+
+- name: Install wkhtmltopdf with patched qt
+  tags: [apt]
+  apt:
+    deb: https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
+    state: present
 
 - name: Update Python 3 pip
   pip:


### PR DESCRIPTION
https://trello.com/c/4Su1kLUN/397-update-apt-get-dependencies-for-e-signature-counterpart-agreement-script

We need the official build of wkhtmltopdf with patched QT to be able to get page numbers working in the latest agreement PDF format. Also, to make sure the fonts are consistent across the document we need Microsoft core fonts installed.