### PR TITLE
Fix typo in publish draft services script

### DIFF
--- a/job_definitions/publish_draft_services.yml
+++ b/job_definitions/publish_draft_services.yml
@@ -67,7 +67,7 @@
           if [ "$DRY_RUN" = "true" ]; then
             FLAGS="$FLAGS --dry-run"
           fi
-          if [ "SKIP_DOCS_IF_PUBLISHED" = "true" ]; then
+          if [ "$SKIP_DOCS_IF_PUBLISHED" = "true" ]; then
             FLAGS="$FLAGS --skip-docs-if-published"
           fi
 


### PR DESCRIPTION
Missing a dollar sign that meant --skip-docs-if-published flag was never added to $FLAGS, meaning that the build would take way longer than needed if restarting a build failed halfway-through.