### PR TITLE
Add stats snapshot for DOS5

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "aws-auth.nix|tests/jenkins-vars.yml",
     "lines": null
   },
-  "generated_at": "2020-08-26T16:21:45Z",
+  "generated_at": "2020-10-08T12:52:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -145,42 +145,42 @@
         "hashed_secret": "dfc63fc900c0cf354c84659a82679844ac5b0db0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5,
+        "line_number": 4,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "1bbfa308bf89a3f50e3629c527585fffb47ab7d9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6,
+        "line_number": 5,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "50afbb4b5f13d64c5112497a6560455fc822ff83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7,
+        "line_number": 6,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "29fedfd30d5d8e1d091a864db11773232d5c9ba3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9,
+        "line_number": 8,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "f148031fafc2002dd179741b4c6d6813c85f8078",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11,
+        "line_number": 10,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8b12f783925d9abe1fb23be01d586ce62b9ad143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 13,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -11,7 +11,7 @@
 {#    ('g-cloud-16', '1fWI3LrnPU1cHVYo_83KWfgND-lng2ztM', False)    #}
 
 {% set frameworks = (
-    ('g-cloud-12', '1LVGqBCRhjpl2OrKaUouh8rEiV3dpBep_', True),
+    ('g-cloud-12', '1LVGqBCRhjpl2OrKaUouh8rEiV3dpBep_', False),
 ) %}
 
 {% set environments = ['production'] %}

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -1,6 +1,5 @@
 {# frameworks = (framework_slug, drive_folder, enabled?) #}
 
-{#    ('digital-outcomes-and-specialists-5', '1KqVLn0yHBt3Sd7BJrNwo1mw7C31HCpPB', False),    #}
 {#    ('digital-outcomes-and-specialists-6', '1QSiKocZbuQeGXqeIKMoNDK4RvvFeNtnb', False),    #}
 {#    ('digital-outcomes-and-specialists-7', '1PZQp2c_3O3fe82POThq6Gea6AHD1L2b0', False),    #}
 {#    ('digital-outcomes-and-specialists-8', '19C-pOTvBh8ki9LOeWBf3AUm_DDVkzqUR', False),    #}
@@ -12,6 +11,7 @@
 
 {% set frameworks = (
     ('g-cloud-12', '1LVGqBCRhjpl2OrKaUouh8rEiV3dpBep_', False),
+    ('digital-outcomes-and-specialists-5', '1KqVLn0yHBt3Sd7BJrNwo1mw7C31HCpPB', True),
 ) %}
 
 {% set environments = ['production'] %}


### PR DESCRIPTION
Ticket: https://trello.com/c/VOfe4Yo4/473-build-a-performance-dashboard

Digital Outcomes and Specialists 5 is coming soon, we want to be able to get stats on the applications. This PR adds the DOS5 framework to the stats snapshot job, so stats will be uploaded to Google Drive, where they will then be picked up by the script to display them as a graph.