### PR TITLE
Add DOS5 stats snapshot jobs to framework lifecycle jobs

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -213,6 +213,8 @@ jenkins_list_views:
       - scan-g-cloud-services-for-bad-words-production
       - hourly-stats-snapshot-g-cloud-12-production
       - daily-stats-snapshot-g-cloud-12-production
+      - hourly-stats-snapshot-digital-outcomes-and-specialists-5-production
+      - daily-stats-snapshot-digital-outcomes-and-specialists-5-production
   - name: "Code backups"
     jobs:
       - backup-digitalmarketplace-admin-frontend


### PR DESCRIPTION
I forgot to do this in #348