### PR TITLE
pass credentials to deploy-app task

### DIFF
--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -65,8 +65,9 @@
                   echo "Current deployed version of ${APPLICATION_NAME}: ${RELEASE_NAME}"
                   currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${APPLICATION_NAME} - #${RELEASE_NAME}"
                 }
-
-                sh("make ${STAGE} deploy-app")
+                withEnv(paas_credentials.tokenize("\n")) {
+                  sh("make ${STAGE} deploy-app")
+                }
               }
             }
           }


### PR DESCRIPTION
https://trello.com/c/TM0mwfiE/2014-add-dockerhub-credentials-to-paas-manifests
We need to pass credentials to the `cf push` command which is part of the `deploy-app` make task in order to pass docker credentials to it.