### PR TITLE
Change install Jenkins task to ensure sources are updated

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/05_jenkins.yml
@@ -13,8 +13,9 @@
 
 - name: Ensure Jenkins is installed.
   apt:
-    name=jenkins=2.*
-    state=present
+    name: jenkins=2.*
+    state: present
+    update_cache: true
   register: jenkins_package_install
 
 - name: Forced restart after first time package installation

--- a/playbooks/roles/jenkins/tasks/05_jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/05_jenkins.yml
@@ -17,6 +17,8 @@
     state: present
     update_cache: true
   register: jenkins_package_install
+  tags:
+    - upgrade_jenkins
 
 - name: Forced restart after first time package installation
   service: name=jenkins state=restarted

--- a/playbooks/roles/jenkins/tasks/05_paas.yml
+++ b/playbooks/roles/jenkins/tasks/05_paas.yml
@@ -11,6 +11,6 @@
 
 - name: Install or update CloudFoundry package
   apt:
-    name: cf-cli=6.33.*
+    name: cf-cli=6.*
     state: present
     update_cache: yes


### PR DESCRIPTION
Running `make jenkins TAGS=jenkins` wasn't updating Jenkins because the apt sources weren't up-to-date. This PR makes sure that the equivalent of `apt update` is run before installing/upgrading the jenkins package.