### PR TITLE
Disable regular database backups

### DIFF
--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -4,6 +4,7 @@
     project-type: pipeline
     description: Takes a dump of the database, compresses it, encrypts it and uploads to S3.
     concurrent: false
+    disabled: true
     triggers:
       - timed: "0 3 * * *"
     parameters:


### PR DESCRIPTION
Our database has now grown too big for this job: `OverflowError: string longer than 2147483647 bytes`

So we're going to disable it until we know what we want to do. We'll rely on the PaaS backups in the mean time.