### PR TITLE
Update playbook and add instructions for creating a new Jenkins instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ the `dm-ssp-jenkins` user. The Client ID and Client Secret must be stored in the
 *jenkins-vars/jenkins.yaml*, and must be stored as a nested dict under `jenkins_github_auth_by_hostname`. This allows
 us to maintain multiple Jenkins instances (if required). These credentials are deployed via the `config` task tag.
 
+## Creating a new Jenkins instance
+
+The process for creating a new instance is documented in [the team manual](https://alphagov.github.io/digitalmarketplace-manual/2nd-line-runbook/rebuilding-jenkins.html).
+
 ## Logging
 
 The Jenkins server captures the following logs:

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -70,6 +70,7 @@ jenkins_plugins:
   - github-oauth
   - htmlpublisher
   - lockable-resources
+  - matrix-auth
   - next-executions
   - nodejs
   - parameterized-trigger

--- a/playbooks/roles/jenkins/tasks/05_jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/05_jenkins.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Add Jenkins apt repository key.
-  apt_key: url="http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key" state=present
+  apt_key: url="https://pkg.jenkins.io/debian-stable/jenkins.io.key" state=present
 
 - name: Add Jenkins apt repository.
-  apt_repository: repo="deb http://pkg.jenkins-ci.org/debian binary/"  state=present update_cache=yes
+  apt_repository: repo="deb https://pkg.jenkins.io/debian-stable binary/"  state=present update_cache=yes
 
 - name: Set Jenkins service boot config
   template: src=jenkins_defaults.j2


### PR DESCRIPTION
While setting up a [new Jenkins instance for the ITHC](https://trello.com/c/nCAuU2nf/558-3-give-the-pentester-a-way-to-test-our-jenkins-instance) I had to update a couple of things in the playbook to get it to work:

1. The official Jenkins apt repository has moved
2. We now need to add `matrix-auth` to the list of plugins.

I've also added instructions to the README covering how to set up a new instance, as there are some things which need to happen outside this repo.