### PR TITLE
Remove tag-dmtestutils job

### DIFF
--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -1,4 +1,4 @@
-{% set packages = ['utils', 'apiclient', 'content-loader', 'test-utils'] %}
+{% set packages = ['utils', 'apiclient', 'content-loader'] %}
 ---
 {% for package in packages %}
 - job:


### PR DESCRIPTION
Creating releases for alphagov/digitalmarketplace-test-utils is now done by GitHub Actions (see alphagov/digitalmarketplace-test-utils#35), we can remove this job.