### PR TITLE
Add DOS 5 to the supplier export job

### DIFF
--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -1,7 +1,7 @@
 {% set environments = ['preview', 'staging', 'production'] %}
 {% set frameworks = [
     'g-cloud-9', 'g-cloud-10', 'g-cloud-11', 'g-cloud-12',
-    'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3', 'digital-outcomes-and-specialists-4'
+    'digital-outcomes-and-specialists-2', 'digital-outcomes-and-specialists-3', 'digital-outcomes-and-specialists-4', 'digital-outcomes-and-specialists-5'
   ]
 %}
 ---


### PR DESCRIPTION
Trello: https://trello.com/c/fQItSqRq/2150-query-dmp-admin-login-for-ccs-and-dos-5-contact-suppliers

We should have done this when we opened DOS 5, but seemingly forgot.

This is the last step in https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html?highlight=export_supplier_data_to_s3#a-open-with-clarification-questions-open