### PR TITLE
Remove job tag-dmcontent-loader

### DIFF
--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -1,4 +1,4 @@
-{% set packages = ['utils', 'apiclient', 'content-loader'] %}
+{% set packages = ['utils', 'apiclient'] %}
 ---
 {% for package in packages %}
 - job:


### PR DESCRIPTION
We want to replace this with GitHub Actions.