### PR TITLE
Add --rm to all Docker run commands

### DIFF
--- a/job_definitions/create_index.yml
+++ b/job_definitions/create_index.yml
@@ -55,5 +55,5 @@
             FLAGS="--serial"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX_NAME}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${MAPPING}" $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX_NAME}" --frameworks="${FRAMEWORKS}" --create-with-mapping="${MAPPING}" $FLAGS
 {% endfor %}

--- a/job_definitions/data_retention.yml
+++ b/job_definitions/data_retention.yml
@@ -31,10 +31,10 @@
             FLAGS="--dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-user-data.py '{{ environment }}' \
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-user-data.py '{{ environment }}' \
             --mailchimp-username="jenkins" \
             --mailchimp-api-key=$MAILCHIMP_API_TOKEN \
             $FLAGS --verbose
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-contact-information-data.py '{{ environment }}' $FLAGS --verbose
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/data-retention-remove-contact-information-data.py '{{ environment }}' $FLAGS --verbose
 {% endfor %}

--- a/job_definitions/export_dos_opportunities.yml
+++ b/job_definitions/export_dos_opportunities.yml
@@ -27,6 +27,6 @@
           # when mounting the volume will otherwise be owned by the root user.
           rm -rf ./data && mkdir data
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/export-dos-opportunities.py '{{ environment }}'
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/export-dos-opportunities.py '{{ environment }}'
 
 {% endfor %}

--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -32,8 +32,8 @@
           # when mounting the volume will otherwise be owned by the root user.
           rm -rf ./data && mkdir data
 {% for framework in frameworks %}
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' suppliers '{{ framework }}'
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' users '{{ framework }}'
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' users '{{ framework }}' --user-research-opted-in
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' suppliers '{{ framework }}'
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' users '{{ framework }}'
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/generate-supplier-user-csv.py '{{ environment }}' users '{{ framework }}' --user-research-opted-in
 {% endfor %}
 {% endfor %}

--- a/job_definitions/general_docker_script_runner.yml
+++ b/job_definitions/general_docker_script_runner.yml
@@ -29,4 +29,4 @@
               CHANNEL=#dm-release
     builders:
       - shell: |
-          docker run digitalmarketplace/scripts $RUN_COMMAND
+          docker run --rm digitalmarketplace/scripts $RUN_COMMAND

--- a/job_definitions/maintenance_mode.yml
+++ b/job_definitions/maintenance_mode.yml
@@ -42,7 +42,7 @@
         currentBuild.displayName = "#${BUILD_NUMBER} - ${STAGE} - ${MODE}"
         node {
           try {
-            sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "${MODE}" "${STAGE}"')
+            sh('docker run --rm -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/maintenance-mode-pr.sh "${MODE}" "${STAGE}"')
           } catch(e) {
             currentBuild.result = 'ABORTED'
             error('Stopping early - possibly no change in maintenance mode, or script failed.')

--- a/job_definitions/mark_definite_framework_results.yml
+++ b/job_definitions/mark_definite_framework_results.yml
@@ -52,7 +52,7 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run \
+          docker run --rm \
             -e DM_DATA_API_TOKEN_{{ environment|upper }} \
             digitalmarketplace/scripts \
               scripts/framework-applications/mark-definite-framework-results.py \

--- a/job_definitions/notify_buyers_to_award_closed_briefs.yml
+++ b/job_definitions/notify_buyers_to_award_closed_briefs.yml
@@ -70,6 +70,6 @@
             FLAGS="$FLAGS --buyer-ids=$BUYER_IDS"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-to-award-closed-briefs.py {{ environment }} $NOTIFY_API_TOKEN $NOTIFY_TEMPLATE_ID $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-to-award-closed-briefs.py {{ environment }} $NOTIFY_API_TOKEN $NOTIFY_TEMPLATE_ID $FLAGS
 {% endfor %}
 {% endfor %}

--- a/job_definitions/notify_buyers_when_requirements_close.yml
+++ b/job_definitions/notify_buyers_when_requirements_close.yml
@@ -45,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --email-api-key="$NOTIFY_API_TOKEN" $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-buyers-when-requirements-close.py '{{ environment }}' --email-api-key="$NOTIFY_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_awarded_briefs.yml
+++ b/job_definitions/notify_suppliers_of_awarded_briefs.yml
@@ -48,5 +48,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-awarded-briefs.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $FLAGS --verbose
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-awarded-briefs.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $FLAGS --verbose
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_brief_withdrawals.yml
+++ b/job_definitions/notify_suppliers_of_brief_withdrawals.yml
@@ -49,5 +49,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-brief-withdrawal.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $PARAMS $FLAGS --verbose
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-brief-withdrawal.py '{{ environment }}' $NOTIFY_API_TOKEN {{ NOTIFY_TEMPLATE_ID }} $PARAMS $FLAGS --verbose
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_dos_opportunities.yml
+++ b/job_definitions/notify_suppliers_of_dos_opportunities.yml
@@ -71,5 +71,5 @@
             FLAGS="$FLAGS --framework_slug=$FRAMEWORK_SLUG"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/send-dos-opportunities-email.py "{{ environment }}" "jenkins" "$MAILCHIMP_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_of_framework_application_events.yml
+++ b/job_definitions/notify_suppliers_of_framework_application_events.yml
@@ -81,7 +81,7 @@
           NOTIFY_TEMPLATE_MAP='{{ notify_template_map | to_json }}'
           NOTIFY_TEMPLATE_ID="$(echo $NOTIFY_TEMPLATE_MAP | jq --raw-output '.[env.EMAIL_TYPE]')"
 
-          docker run -e \
+          docker run --rm -e \
             "DM_DATA_API_TOKEN_{{ environment|upper }}" \
             digitalmarketplace/scripts scripts/framework-applications/notify-suppliers-of-framework-application-event.py \
             "{{ environment }}" \

--- a/job_definitions/notify_suppliers_of_new_questions_answers.yml
+++ b/job_definitions/notify_suppliers_of_new_questions_answers.yml
@@ -45,5 +45,5 @@
             FLAGS="$FLAGS --dry-run"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $NOTIFY_API_TOKEN $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-of-new-questions-answers.py {{ environment }} $NOTIFY_API_TOKEN $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
+++ b/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
@@ -50,5 +50,5 @@
             $FLAGS="$FLAGS --supplier-id='$SUPPLIER_IDS'"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-whether-application-made-for-framework.py "{{ environment }}" "$FRAMEWORK_SLUG" "$NOTIFY_API_TOKEN" $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/notify-suppliers-whether-application-made-for-framework.py "{{ environment }}" "$FRAMEWORK_SLUG" "$NOTIFY_API_TOKEN" $FLAGS
 {% endfor %}

--- a/job_definitions/notify_suppliers_with_incomplete_applications.yml
+++ b/job_definitions/notify_suppliers_with_incomplete_applications.yml
@@ -54,7 +54,7 @@
           if [ "$DRY_RUN" = "true" ]; then
             FLAGS="--dry-run"
           fi
-          docker run -e \
+          docker run --rm -e \
             DM_DATA_API_TOKEN_{{ environment|upper }} \
             digitalmarketplace/scripts scripts/notify-suppliers-with-incomplete-applications.py \
             '{{ environment }}' \

--- a/job_definitions/publish_draft_services.yml
+++ b/job_definitions/publish_draft_services.yml
@@ -71,7 +71,7 @@
             FLAGS="$FLAGS --skip-docs-if-published"
           fi
 
-          docker run \
+          docker run --rm \
             -v $HOME/.aws:/root/.aws \
             -e DM_DATA_API_TOKEN_{{ environment|upper }} \
             -e AWS_PROFILE="${AWS_PROFILE}-infrastructure" \

--- a/job_definitions/rotate_api_tokens.yml
+++ b/job_definitions/rotate_api_tokens.yml
@@ -88,7 +88,7 @@
 {% endif %}
           node {
             try {
-              sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh "{{ stage.command }}" "${STAGE}"')
+              sh('docker run --rm -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh "{{ stage.command }}" "${STAGE}"')
 
               notify_slack(':spinner:', '{{ stage.name }} - SUCCESS')
 

--- a/job_definitions/rotate_callback_token.yml
+++ b/job_definitions/rotate_callback_token.yml
@@ -68,7 +68,7 @@
         stage("{{ job_stage.name }}") {
           node {
             try {
-              sh('docker run -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh "{{ job_stage.command }}" "{{ environment }}"')
+              sh('docker run --rm -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh "{{ job_stage.command }}" "{{ environment }}"')
 
               notify_slack(':spinner:', '{{ job_stage.name }} - SUCCESS')
 

--- a/job_definitions/scan_g_cloud_services_for_bad_words.yml
+++ b/job_definitions/scan_g_cloud_services_for_bad_words.yml
@@ -54,7 +54,7 @@
                 FLAGS="--scan-drafts"
               fi
 
-              docker run \
+              docker run --rm \
                 -e DM_DATA_API_TOKEN_{{ environment|upper }} \
                 --volume \$(pwd)/data:/app/data digitalmarketplace/scripts \
                 ./scripts/framework-applications/scan-g-cloud-services-for-bad-words.py \

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -91,7 +91,7 @@
             }
             stage("Export statistics") {
               sh('''
-                docker run \
+                docker run --rm \
                   -e DM_DATA_API_TOKEN_{{ environment|upper }} \
                   --user $(id -u) \
                   --volume $(pwd)/data:/app/data \

--- a/job_definitions/update_index.yml
+++ b/job_definitions/update_index.yml
@@ -55,5 +55,5 @@
             FLAGS="--serial"
           fi
 
-          docker run -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX}" --frameworks="${FRAMEWORKS}" $FLAGS
+          docker run --rm -e DM_DATA_API_TOKEN_{{ environment|upper }} -e DM_SEARCH_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/index-to-search-service.py "${OBJECTS}" '{{ environment }}' --index="${INDEX}" --frameworks="${FRAMEWORKS}" $FLAGS
 {% endfor %}

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -35,7 +35,7 @@
       node {
         stage('Update alias'){
           sh('''
-            docker run \
+            docker run --rm \
               -e "DM_SEARCH_API_TOKEN_{{ environment|upper }}" \
               -e "DM_DATA_API_TOKEN_{{ environment|upper }}" \
               digitalmarketplace/scripts \

--- a/job_definitions/upload_dos_opportunities_email_list.yml
+++ b/job_definitions/upload_dos_opportunities_email_list.yml
@@ -29,5 +29,5 @@
               CHANNEL=#dm-2ndline
     builders:
       - shell: |
-          docker run -e DM_DATA_API_TOKEN_PRODUCTION digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }}
+          docker run --rm -e DM_DATA_API_TOKEN_PRODUCTION digitalmarketplace/scripts scripts/upload-dos-opportunities-email-list.py "production" "jenkins" "$MAILCHIMP_API_TOKEN" {{ framework_slug }}
 {% endfor %}

--- a/job_definitions/virus_scan_s3_bucket.yml
+++ b/job_definitions/virus_scan_s3_bucket.yml
@@ -37,7 +37,7 @@
             CONCURRENCY="0"
           fi
 
-          docker run -e DM_ANTIVIRUS_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/virus-scan-s3-bucket.py {{ environment }} ${BUCKETS} --concurrency="${CONCURRENCY}" --prefix="${PREFIX}" ${FLAGS}
+          docker run --rm -e DM_ANTIVIRUS_API_TOKEN_{{ environment|upper }} digitalmarketplace/scripts scripts/virus-scan-s3-bucket.py {{ environment }} ${BUCKETS} --concurrency="${CONCURRENCY}" --prefix="${PREFIX}" ${FLAGS}
 - job:
     name: "virus-scan-s3-buckets-nightly-{{ environment }}"
     display-name: "Virus scan S3 buckets nightly - {{ environment }}"


### PR DESCRIPTION
We have a lot of dangling containers on our Jenkins instance, we should make sure to clean them up when they are not used. Adding `--rm` to everywhere we use `docker run` is a quick fix.