### PR TITLE
Add warning to job description

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -19,7 +19,7 @@
           <li>Upload the generated files to S3 and set the path in the relevant FrameworkAgreement record</li>
           <li>Send an email to all active users on the supplier account that the counterpart file has been uploaded</li>
         </ol>
-        <p>Do not manually run this job against Production in working hours, this is because of a possible race condition if suppliers re-sign whilst the script is running as described in <a href="https://trello.com/c/lPJCI12q">https://trello.com/c/lPJCI12q</a></p>
+        <p>Do not manually run this job against Production in working hours. There is a possible race condition if suppliers re-sign whilst the script is running as described in <a href="https://trello.com/c/lPJCI12q">https://trello.com/c/lPJCI12q</a></p>
     project-type: pipeline
     concurrent: false
     properties:

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -19,6 +19,7 @@
           <li>Upload the generated files to S3 and set the path in the relevant FrameworkAgreement record</li>
           <li>Send an email to all active users on the supplier account that the counterpart file has been uploaded</li>
         </ol>
+        <p>Do not manually run this job against Production in working hours, this is because of a possible race condition if suppliers re-sign whilst the script is running as described in <a href="https://trello.com/c/lPJCI12q">https://trello.com/c/lPJCI12q</a></p>
     project-type: pipeline
     concurrent: false
     properties:


### PR DESCRIPTION
https://trello.com/c/lPJCI12q/776-3-race-condition-where-supplier-signs-between-generate-documents-and-upload-documents-scripts-running

In lieu of fixing the root cause we can add a warning to the job description to make this less likely to happen.