### PR TITLE
Add main to branches to backup for code backups

### DIFF
--- a/job_definitions/code_backups.yml
+++ b/job_definitions/code_backups.yml
@@ -44,6 +44,7 @@
           credentials-id: github_com_and_enterprise
           branches:
             - master
+            - main
           wipe-workspace: false
     properties:
       - build-discarder:


### PR DESCRIPTION
Ticket: https://trello.com/c/DrVWMkcZ/2169-rename-default-branches-on-our-repos-from-master-to-main

We are renaming our default branches in our git repos to `main`, so we want to back those up as well as/instead of branches named `master`.

While we are in the process of migrating (which could take a while), we just cover all our bases.