### PR TITLE
delete code before backup

### DIFF
--- a/job_definitions/code_backups.yml
+++ b/job_definitions/code_backups.yml
@@ -57,6 +57,7 @@
       - ansicolor
     builders:
       - shell: |
+          rm -rf {{ package }}
           git clone https://$GITHUB_ACCESS_TOKEN@github.com/alphagov/{{ package }} {{ package }} --mirror
           cd {{ package }}
           git remote add {{ package }}-aws-backup-remote https://git-codecommit.eu-west-1.amazonaws.com/v1/repos/{{ package }}


### PR DESCRIPTION
https://trello.com/c/DrVWMkcZ/2169-rename-default-branches-on-our-repos-from-master-to-main

If a previous job fails it can leave a non-empty folder which causes subsequent jobs to fail:
e.g.
```
git clone https://4c3123d80a3e5000b9ed2ae0556f2dfb026d17b4@github.com/alphagov/digitalmarketplace-runner digitalmarketplace-runner --mirror
fatal: destination path 'digitalmarketplace-runner' already exists and is not an empty directory.
```
To fix this we delete the folder in case it exists when the job starts.
