### PR TITLE
Remove job tag-dmutils

### DIFF
--- a/job_definitions/tag_dmutils.yml
+++ b/job_definitions/tag_dmutils.yml
@@ -1,4 +1,4 @@
-{% set packages = ['utils', 'apiclient'] %}
+{% set packages = ['apiclient'] %}
 ---
 {% for package in packages %}
 - job:


### PR DESCRIPTION
We want to do this with GitHub Actions instead (see https://github.com/alphagov/digitalmarketplace-utils/pull/600)