### PR TITLE
Install postgres 12 client

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -31,7 +31,6 @@ dist_tools:
   - libyaml-dev
   - make
   - ntp
-  - postgresql-client
   - python3-dev
   - python3-pip
   - python3-venv

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -31,6 +31,7 @@ dist_tools:
   - libyaml-dev
   - make
   - ntp
+  - postgresql-client-12
   - python3-dev
   - python3-pip
   - python3-venv

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -9,10 +9,12 @@
   shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
 
 - name: Add key for Postgres repo
+  tags: [apt]
   apt_key: url=https://www.postgresql.org/media/keys/ACCC4CF8.asc state=present
   sudo: yes
 
 - name: Add Postgres repo to sources list
+  tags: [apt]
   apt_repository: repo='deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' state=present
   sudo: yes
 

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -8,6 +8,14 @@
   tags: [apt]
   shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
 
+- name: Add key for Postgres repo
+  apt_key: url=https://www.postgresql.org/media/keys/ACCC4CF8.asc state=present
+  sudo: yes
+
+- name: Add Postgres repo to sources list
+  apt_repository: repo='deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' state=present
+  sudo: yes
+
 - name: Install tools
   tags: [apt]
   apt:


### PR DESCRIPTION
https://trello.com/c/OVbPpbWM/837-1-upgrade-staging-and-production-to-postgres-12
For scripts which rely on the postgres client installed directly on the Jenkins instance, we need to make sure this matches the postgres version we are running on PaaS.

This is an ansible-ified version of the steps in https://www.postgresql.org/download/linux/ubuntu/
I have also tested these steps manually on the Jenkins instance.