### PR TITLE
Throttle functional tests to 1 concurrent per environment

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -19,6 +19,11 @@
       - build-discarder:
           days-to-keep: 60
           num-to-keep: 100
+      - throttle:
+          max-total: 1
+          categories:
+            - EndToEndTests-{{ job.environment }}
+          option: category
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -20,9 +20,8 @@
           days-to-keep: 60
           num-to-keep: 100
       - throttle:
-          max-total: 1
           categories:
-            - EndToEndTests-{{ job.environment }}
+            - EndToEndTest-{{ job.environment }}
           option: category
     parameters:
       - string:

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -42,6 +42,10 @@
       - build-discarder:
           days-to-keep: 30
           num-to-keep: 1000
+      - throttle:
+          categories:
+            - EndToEndTest-{{ environment }}
+          option: category
     parameters:
       - string:
           name: FT_BRANCH_NAME

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -89,6 +89,7 @@ jenkins_config_templates:
   - jenkins.model.DownloadSettings.xml
   - com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView.xml
   - jenkins.model.JenkinsLocationConfiguration.xml
+  - hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml
 
 build_monitor_jobs:
   - apps-are-up-preview

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -76,6 +76,7 @@ jenkins_plugins:
   - parameterized-trigger
   - postbuildscript
   - rebuild
+  - throttle-concurrents
   - translation
   - workflow-aggregator  # aka 'Pipeline' suite
 

--- a/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
@@ -1,0 +1,22 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl plugin="throttle-concurrents@2.1">
+  <categories class="java.util.concurrent.CopyOnWriteArrayList">
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>1</maxConcurrentTotal>
+      <categoryName>EndToEndTest-preview</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentTotal>1</maxConcurrentTotal>
+      <categoryName>EndToEndTest-staging</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentTotal>1</maxConcurrentTotal>
+      <categoryName>EndToEndTest-production</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+  </categories>
+  <throttledPipelinesByCategory class="tree-map"/>
+</hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl>


### PR DESCRIPTION
https://trello.com/c/wQ81VZI1/870-prevent-the-functional-tests-from-running-concurrently
We sometimes encounter race conditions where multiple end-to-end tests are running simultaneously on the same environment. This uses a plugin to limit them to not run concurrently.