### PR TITLE
Throttle app pipelines to 4 concurrent jobs

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -6,6 +6,11 @@
     project-type: pipeline
     description: Promote {{ application }} through environments
     concurrent: true
+    properties:
+      - throttle:
+          categories:
+            - AppPipelines
+          option: category
     triggers:
       - pollscm:
           cron: "* * * * *"

--- a/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
@@ -17,6 +17,11 @@
       <categoryName>EndToEndTest-production</categoryName>
       <nodeLabeledPairs/>
     </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentTotal>4</maxConcurrentTotal>
+      <categoryName>AppPipelines</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
   </categories>
   <throttledPipelinesByCategory class="tree-map"/>
 </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl>


### PR DESCRIPTION
We recently had a near-miss deadlock. This is because we had a large number of app pipeline jobs all in progress. However, they were all blocked on a deploy job, so could not make progress. However, all the deploy jobs were blocked on other jobs, mainly notifying Slack. However, the jobs in this third tier couldn't be scheduled because all the executors were full of blocked jobs in the first and second tier. I had to delete some jobs in the first tier to unblock Jenkins.

Introduce throttling on the app pipelines. Now, no more than 4 can run at once. This means that in the worst case, only 12 executor slots will be occupied by jobs related to app pipelines. So other jobs will still be able to run. I think this should make it much harder to accidentally deadlock Jenkins.

Copies extensively from https://github.com/alphagov/digitalmarketplace-jenkins/pull/395, which introduced throttling.