### PR TITLE
Add digitalmarketplace-developer-tools to code backups

### DIFF
--- a/job_definitions/code_backups.yml
+++ b/job_definitions/code_backups.yml
@@ -12,6 +12,7 @@
     "digitalmarketplace-buyer-frontend",
     "digitalmarketplace-content-loader",
     "digitalmarketplace-credentials",
+    "digitalmarketplace-developer-tools",
     "digitalmarketplace-docker-base",
     "digitalmarketplace-frameworks",
     "digitalmarketplace-frontend-toolkit",


### PR DESCRIPTION
We created the CodeCommit repo in https://github.com/alphagov/digitalmarketplace-aws/pull/861. Now we can add the job to do the backup.