### PR TITLE
Revert "Throttle app pipelines to 4 concurrent jobs"

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -6,11 +6,6 @@
     project-type: pipeline
     description: Promote {{ application }} through environments
     concurrent: true
-    properties:
-      - throttle:
-          categories:
-            - AppPipelines
-          option: category
     triggers:
       - pollscm:
           cron: "* * * * *"

--- a/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
@@ -17,11 +17,6 @@
       <categoryName>EndToEndTest-production</categoryName>
       <nodeLabeledPairs/>
     </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
-    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
-      <maxConcurrentTotal>4</maxConcurrentTotal>
-      <categoryName>AppPipelines</categoryName>
-      <nodeLabeledPairs/>
-    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
   </categories>
   <throttledPipelinesByCategory class="tree-map"/>
 </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl>


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-jenkins#400

The throttling appears to count runs that aren't using executors, so this needs more work, because currently our pipelines won't run.