### PR TITLE
Change build-image parameter REBUILD to default true

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -17,7 +17,7 @@
           description: "git ref (eg 'release-42') to checkout for building the artefact. This will also become the image release name."
       - bool:
           name: REBUILD
-          default: false
+          default: true
           description: "Rerun the build even if the release already exists"
       - string:
           name: HEAD_BRANCH


### PR DESCRIPTION
We want to be able to rebuild Docker images for apps after base images have been rebuilt, so we can get the latest version of security patches.  This commit changes the default of the build-image job so that it will not skip the Docker build if the release tag for the app image already exists on Docker Hub. Because the Docker client is already pretty good at caching build products this shouldn't result in much wasted work.