### PR TITLE
Make common tags into their own targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ keys: requirements ## Update all the keys used and accepted by Jenkins
 jobs: requirements ## Update all Jenkins jobs
 	TAGS=jobs ./deploy-jenkins.sh
 
+# Includes 'jobs' - otherwise views disappear
 .PHONY: reconfigure
 reconfigure: requirements ## Update the Jenkins configuration and jobs
-	TAGS=config ./deploy-jenkins.sh
+	TAGS="config,jobs" ./deploy-jenkins.sh
 
 .PHONY: upgrade
 upgrade: requirements ## Upgrade Jenkins

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || echo ${VIRTUAL_ENV})
+export VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || echo ${VIRTUAL_ENV})
 
 export ANSIBLE_ROLES_PATH := ${VIRTUALENV_ROOT}/etc/ansible/roles
 export ANSIBLE_CONFIG := playbooks/ansible.cfg
@@ -40,21 +40,26 @@ clean: ## Clean workspace (delete all generated files)
 	rm -rf venv requirements.txt.md5
 
 .PHONY: jenkins
-jenkins: requirements ## Run Jenkins playbook
+jenkins: requirements ## Run Jenkins playbook specified by TAGS
 	$(if ${TAGS},,$(error Must specify a list of ansible tags in TAGS))
-	@set -e ;\
-	${DM_CREDENTIALS_REPO}/sops-wrapper -v > /dev/null ;\
-	JENKINS_VARS_FILE=$$(mktemp) ;\
-	PRIVATE_KEY_FILE=$$(mktemp) ;\
-	trap 'rm $$JENKINS_VARS_FILE $$PRIVATE_KEY_FILE' EXIT ;\
-	for varfile in ${DM_CREDENTIALS_REPO}/jenkins-vars/*.yaml; do \
-	${DM_CREDENTIALS_REPO}/sops-wrapper -d $$varfile >> $$JENKINS_VARS_FILE ;\
-	done ;\
-	${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem.enc > $$PRIVATE_KEY_FILE ;\
-	ANSIBLE_CONFIG=playbooks/ansible.cfg ${VIRTUALENV_ROOT}/bin/ansible-playbook \
-		-i playbooks/hosts playbooks/jenkins_playbook.yml \
-		-e @$$JENKINS_VARS_FILE \
-		-e "jenkins_public_key='$$(ssh-keygen -y -f $$PRIVATE_KEY_FILE)'" \
-		--key-file=$$PRIVATE_KEY_FILE \
-		-e "dm_credentials_repo=${DM_CREDENTIALS_REPO}" \
-		--tags "${TAGS}" ${EXTRA_VARS}
+	./deploy-jenkins.sh
+
+.PHONY: install
+install: requirements ## Completely (re)install Jenkins
+	TAGS=all ./deploy-jenkins.sh
+
+.PHONY: keys
+keys: requirements ## Update all the keys used and accepted by Jenkins
+	TAGS=keys ./deploy-jenkins.sh
+
+.PHONY: jobs
+jobs: requirements ## Update all Jenkins jobs
+	TAGS=jobs ./deploy-jenkins.sh
+
+.PHONY: reconfigure
+reconfigure: requirements ## Update the Jenkins configuration and jobs
+	TAGS=config ./deploy-jenkins.sh
+
+.PHONY: upgrade
+upgrade: requirements ## Upgrade Jenkins
+	TAGS=jenkins ./deploy-jenkins.sh

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ To make changes to Jenkins configuration or jobs, you will need:
 
 ### Updating jobs
 
-The Ansible tasks are grouped by tags. See `/playbooks/roles/jenkins/tasks/main.yml`.
+The Ansible tasks are grouped by tags. See [`playbooks/roles/jenkins/tasks/main.yml`](playbooks/roles/jenkins/tasks/main.yml). Use `make jenkins` to run a particular set of tagged tasks.
 
 To update all job definitions (i.e. run the Ansible tasks tagged as `jobs`):
 ```bash
-$ make jenkins TAGS=jobs
+$ make jobs
 ```
 
 To only update a specific Jenkins job:
 ```bash
-$ make jenkins TAGS=jobs JOBS=index_services
+$ make jobs JOBS=index_services
 ```
 
 Usually, the Jenkins jobs you push onto the server will be enabled. However if you're setting up a new box, you will
 want to disable them, which can be done as follows:
 ```bash
-$ make jenkins TAGS=jobs JOBS_DISABLED=true
+$ make jobs JOBS_DISABLED=true
 ```
 
 Jobs will also be disabled if you are bootstrapping the box from scratch (i.e. if the `bootstrap`
@@ -46,12 +46,12 @@ before running them.
 
 To update Jenkins settings (e.g. adding a job to a tab group in the UI):
 ```bash
-$ make jenkins TAGS=config
+$ make reconfigure
 ```
 
 To upgrade the Jenkins version:
 ```bash
-$ make jenkins TAGS=jenkins
+$ make upgrade
 ```
 
 ### Troubleshooting
@@ -84,7 +84,7 @@ All GitHub-associated SSH keys for trusted users should work. However if the SSH
 been added to the Github account, you may need to re-gather the keys with:
 
 ```bash
-make jenkins TAGS=keys
+make keys
 ```
 
 ## Running scripts with Python3 via a Jenkins job

--- a/deploy-jenkins.sh
+++ b/deploy-jenkins.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+set -eou pipefail
+# Script to run ansible tasks. Use the Makefile instead of running this directly.
+
+${DM_CREDENTIALS_REPO}/sops-wrapper -v > /dev/null
+
+JENKINS_VARS_FILE=$(mktemp)
+PRIVATE_KEY_FILE=$(mktemp)
+trap 'rm $JENKINS_VARS_FILE $PRIVATE_KEY_FILE' EXIT
+
+for varfile in ${DM_CREDENTIALS_REPO}/jenkins-vars/*.yaml
+do
+  ${DM_CREDENTIALS_REPO}/sops-wrapper -d $varfile >> $JENKINS_VARS_FILE
+done
+${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem.enc > $PRIVATE_KEY_FILE
+
+echo ${VIRTUALENV_ROOT}/bin/ansible-playbook \
+  -i playbooks/hosts playbooks/jenkins_playbook.yml \
+  -e @$JENKINS_VARS_FILE \
+  -e "jenkins_public_key='$(ssh-keygen -y -f $PRIVATE_KEY_FILE)'" \
+  --key-file=$PRIVATE_KEY_FILE \
+  -e "dm_credentials_repo=${DM_CREDENTIALS_REPO}" \
+  --tags "${TAGS}" ${EXTRA_VARS:-}


### PR DESCRIPTION
https://trello.com/c/03kE0zPn/858-05-create-more-explicit-make-targets-in-digitalmarketplace-jenkins

We recently had [an incident](https://docs.google.com/document/d/15rVb16Nex37ZF8DJsLBSUcAeYxNPlWabxr4c6feRwO0) during which a developer accidentally ran `make jenkins` using the wrong tag and caused Jenkins to restart at an inopportune moment.

Add targets for the most common tags. This should make it a bit more difficult to do the wrong thing in future.

Leave the existing target so that people can still choose to run uncommon tags. This avoids us needing to maintain a vast list of rarely-used targets.

We'll need to update the team manual after this gets merged.

Also, update `jobs` when we update `config` to fix https://trello.com/c/PWoPSBNv