### PR TITLE
Export variables needed by Jenkins deploy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ export ANSIBLE_CONFIG := playbooks/ansible.cfg
 
 # extra variables that, if specified, will override those in playbooks/roles/jenkins/defaults/main.yml
 ifdef JOBS_DISABLED
-	EXTRA_VARS += -e 'jobs_disabled=${JOBS_DISABLED}'
+	export EXTRA_VARS += -e 'jobs_disabled=${JOBS_DISABLED}'
 endif
 ifdef JOBS
-	EXTRA_VARS += -e 'jobs=${JOBS}'
+	export EXTRA_VARS += -e 'jobs=${JOBS}'
 endif
 
 .PHONY: help


### PR DESCRIPTION
https://trello.com/c/03kE0zPn/858-05-create-more-explicit-make-targets-in-digitalmarketplace-jenkins

We need to export the variables so that they're available inside the script.

Fixes bug introduced in https://github.com/alphagov/digitalmarketplace-jenkins/pull/405