### PR TITLE
Add job to update jenkins job definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ${VIRTUALENV_ROOT}/activate:
 
 .PHONY: requirements
 requirements: venv ## Install requirements
+	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
 	${VIRTUALENV_ROOT}/bin/ansible-galaxy install -r playbooks/requirements.yml
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To make changes to Jenkins configuration or jobs, you will need:
 
 The Ansible tasks are grouped by tags. See [`playbooks/roles/jenkins/tasks/main.yml`](playbooks/roles/jenkins/tasks/main.yml). Use `make jenkins` to run a particular set of tagged tasks.
 
+All job definitions will be updated automaticaly when merged to `main`. This is perfomed by the [`job_definitions/update_jenkins_job_definitions.yml`](job_definitions/update_jenkins_job_definitions.yml) job.
+
+If you need to test a job from a branch or deploy manually you can run the commands below from your local machine:
+
 To update all job definitions (i.e. run the Ansible tasks tagged as `jobs`):
 ```bash
 $ make jobs

--- a/deploy-jenkins.sh
+++ b/deploy-jenkins.sh
@@ -28,9 +28,19 @@ then
   EXTRA_VARS+=(--extra-vars "jobs_disabled=${JOBS_DISABLED}")
 fi
 
+if [ ! -z ${LOCALHOST+x} ]
+  then 
+    INVENTORY="localhost, ";
+    PLAYBOOK="playbooks/jenkins_playbook_local.yml"; 
+    EXTRA_VARS+=(--connection "local")
+  else
+    INVENTORY="playbooks/hosts"
+    PLAYBOOK="playbooks/jenkins_playbook.yml"
+fi
+
 ${VIRTUALENV_ROOT}/bin/ansible-playbook \
-  playbooks/jenkins_playbook.yml \
-  --inventory playbooks/hosts \
+  $PLAYBOOK \
+  --inventory $INVENTORY \
   --key-file=$PRIVATE_KEY_FILE \
   --tags "${TAGS}" \
   "${EXTRA_VARS[@]}"

--- a/deploy-jenkins.sh
+++ b/deploy-jenkins.sh
@@ -30,17 +30,15 @@ fi
 
 if [ ! -z ${LOCALHOST+x} ]
 then 
-  INVENTORY="localhost, ";
   PLAYBOOK="playbooks/jenkins_playbook_local.yml"; 
   EXTRA_VARS+=(--connection "local")
 else
-  INVENTORY="playbooks/hosts"
   PLAYBOOK="playbooks/jenkins_playbook.yml"
+  EXTRA_VARS+=(--inventory "playbooks/hosts")
 fi
 
 ${VIRTUALENV_ROOT}/bin/ansible-playbook \
   $PLAYBOOK \
-  --inventory $INVENTORY \
   --key-file=$PRIVATE_KEY_FILE \
   --tags "${TAGS}" \
   "${EXTRA_VARS[@]}"

--- a/deploy-jenkins.sh
+++ b/deploy-jenkins.sh
@@ -29,13 +29,13 @@ then
 fi
 
 if [ ! -z ${LOCALHOST+x} ]
-  then 
-    INVENTORY="localhost, ";
-    PLAYBOOK="playbooks/jenkins_playbook_local.yml"; 
-    EXTRA_VARS+=(--connection "local")
-  else
-    INVENTORY="playbooks/hosts"
-    PLAYBOOK="playbooks/jenkins_playbook.yml"
+then 
+  INVENTORY="localhost, ";
+  PLAYBOOK="playbooks/jenkins_playbook_local.yml"; 
+  EXTRA_VARS+=(--connection "local")
+else
+  INVENTORY="playbooks/hosts"
+  PLAYBOOK="playbooks/jenkins_playbook.yml"
 fi
 
 ${VIRTUALENV_ROOT}/bin/ansible-playbook \

--- a/job_definitions/update_jenkins_job_definitions.yml
+++ b/job_definitions/update_jenkins_job_definitions.yml
@@ -3,15 +3,12 @@
     display-name: "Update Jenkins Job Definitions"
     project-type: pipeline
     concurrent: false
+    triggers:
+      - pollscm:
+          cron: "* * * * *"
     disabled: false
     description: |
       <p>This job updates Jenkins jobs using the job definitions from https://github.com/alphagov/digitalmarketplace-jenkins</p>
-    scm:
-      - git:
-          url: git@github.com:alphagov/digitalmarketplace-jenkins.git
-          credentials-id: github_com_and_enterprise
-          branches:
-            - "main"
     wrappers:
       - ansicolor
     dsl: |

--- a/job_definitions/update_jenkins_job_definitions.yml
+++ b/job_definitions/update_jenkins_job_definitions.yml
@@ -15,7 +15,7 @@
       node {
         try {
             stage('Clone digitalmarketplace-jenkins') {
-              git url: 'git@github.com:alphagov/digitalmarketplace-jenkins.git', branch: 'update-jobs', credentialsId: 'github_com_and_enterprise', poll: true 
+              git url: 'git@github.com:alphagov/digitalmarketplace-jenkins.git', branch: 'main', credentialsId: 'github_com_and_enterprise', poll: true
             }
             stage('Update jobs') {
               withEnv([

--- a/job_definitions/update_jenkins_job_definitions.yml
+++ b/job_definitions/update_jenkins_job_definitions.yml
@@ -1,0 +1,44 @@
+- job:
+    name: "update-jenkins-job-definitions"
+    display-name: "Update Jenkins Job Definitions"
+    project-type: pipeline
+    concurrent: false
+    disabled: false
+    description: |
+      <p>This job updates Jenkins jobs using the job definitions from https://github.com/alphagov/digitalmarketplace-jenkins</p>
+    scm:
+      - git:
+          url: git@github.com:alphagov/digitalmarketplace-jenkins.git
+          credentials-id: github_com_and_enterprise
+          branches:
+            - "main"
+    wrappers:
+      - ansicolor
+    dsl: |
+      node {
+        try {
+            stage('Clone digitalmarketplace-jenkins') {
+              git url: 'git@github.com:alphagov/digitalmarketplace-jenkins.git', branch: 'update-jobs', credentialsId: 'github_com_and_enterprise', poll: true 
+            }
+            stage('Update jobs') {
+              withEnv([
+                "DM_CREDENTIALS_REPO=/var/lib/jenkins/digitalmarketplace-credentials"
+                ]) {
+                 sh('make jobs LOCALHOST=true') 
+                }
+            }
+          }
+            catch(err) {
+            currentBuild.result = 'FAILURE'
+            echo "Error: ${err}"
+            build job: 'notify-slack', parameters: [
+              string(name: 'USERNAME', value: 'update_jenkins_job_definitions'),
+              string(name: 'JOB', value: "Update Jenkins Job Definitions"),
+              string(name: 'ICON', value: ':jenkins:'),
+              string(name: 'STAGE', value: "production"),
+              string(name: 'STATUS', value: 'FAILED'),
+              string(name: 'CHANNEL', value: '#dm-2ndline'),
+              text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
+            ]
+          }
+        }

--- a/playbooks/jenkins_playbook_local.yml
+++ b/playbooks/jenkins_playbook_local.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  name: Setup Jenkins CI, config and dependencies
+  roles:
+    - jenkins

--- a/playbooks/roles/jenkins/tasks/10_jobs.yml
+++ b/playbooks/roles/jenkins/tasks/10_jobs.yml
@@ -9,11 +9,11 @@
   pip:
     requirements: /tmp/jenkins-jobs-python-requirements.txt
 
-- name: Create /etc/jenkins_jobs/definitions
-  file: path=/etc/jenkins_jobs/definitions state=directory recurse=yes
+- name: Create /var/lib/jenkins/jenkins_jobs/definitions
+  file: path=/var/lib/jenkins/jenkins_jobs/definitions state=directory recurse=yes owner=jenkins
 
 - name: Deploy jenkins_jobs.ini
-  template: dest=/etc/jenkins_jobs/jenkins_jobs.ini src=jenkins_jobs.ini.j2
+  template: dest=/var/lib/jenkins/jenkins_jobs/jenkins_jobs.ini src=jenkins_jobs.ini.j2 owner=jenkins
 
 - name: Clone digitalmarketplace-credentials repository
   tags: [credentials-repo]
@@ -26,23 +26,23 @@
 - name: Remove deleted or renamed definitions
   synchronize:
     src: '../../../../job_definitions/'
-    dest: '/etc/jenkins_jobs/definitions/'
+    dest: '/var/lib/jenkins/jenkins_jobs/definitions'
     delete: yes
     archive: no
     recursive: yes
     rsync_opts: ['--ignore-existing']
 
 - name: Upload jenkins jobs definitions
-  template: src={{ item }} dest=/etc/jenkins_jobs/definitions/
+  template: src={{ item }} dest=/var/lib/jenkins/jenkins_jobs/definitions/ owner=jenkins
   with_fileglob:
     - '../../../../job_definitions/{{ jobs }}.yml'
 
 - name: Test job definitions before updating (as jenkins user)
-  command: jenkins-jobs test /etc/jenkins_jobs/definitions
+  command: jenkins-jobs test /var/lib/jenkins/jenkins_jobs/definitions
   become: yes
   become_user: jenkins
 
 - name: Update job definitions (as jenkins user)
-  command: jenkins-jobs update /etc/jenkins_jobs/definitions
+  command: jenkins-jobs update /var/lib/jenkins/jenkins_jobs/definitions
   become: yes
   become_user: jenkins


### PR DESCRIPTION
https://trello.com/c/FF0uZCy3/859-2-spike-add-a-job-to-automatically-update-jenkins-job-definitions

This required some related changes to allow the ansible task to run on localhost rather than over SSH.
* Add `LOCALHOST` argument to Makefile to allow localhost settings overrides
* Change paths to location writable by 'jenkins' user
* Add playbook suitable for local deployment

I have tested this on Jenkins against this branch e.g. https://ci.marketplace.team/job/update-jenkins-job-definitions/3/console
