### PR TITLE
Move extra variable calculation into bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,6 @@ export VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || 
 export ANSIBLE_ROLES_PATH := ${VIRTUALENV_ROOT}/etc/ansible/roles
 export ANSIBLE_CONFIG := playbooks/ansible.cfg
 
-# extra variables that, if specified, will override those in playbooks/roles/jenkins/defaults/main.yml
-ifdef JOBS_DISABLED
-	export EXTRA_VARS += -e 'jobs_disabled=${JOBS_DISABLED}'
-endif
-ifdef JOBS
-	export EXTRA_VARS += -e 'jobs=${JOBS}'
-endif
-
 .PHONY: help
 help: ## List available commands
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
https://trello.com/c/03kE0zPn/858-05-create-more-explicit-make-targets-in-digitalmarketplace-jenkins

Previously, we constructed `EXTRA_VARS` in make, which bash interpreted (and passed to ansible) as a single string. Ansible did not recognise this as a valid extra var.

Now, we construct `EXTRA_VARS` in bash, where we can use a bash array to ensure that it all works correctly.

Also replace short options with long options for legibility.

Fixes the final bug I introduced in https://github.com/alphagov/digitalmarketplace-jenkins/pull/405. We've now tested that this works by running it against the real Jenkins (from both MacOS and Ubuntu).