### PR TITLE
Update Docker directory config

### DIFF
--- a/playbooks/roles/jenkins/files/docker_daemon.json
+++ b/playbooks/roles/jenkins/files/docker_daemon.json
@@ -1,3 +1,3 @@
 {
-    "graph": "/data/docker"
+    "data-root": "/data/docker"
 }


### PR DESCRIPTION
`graph` was deprecated in Docker v17.05[[1]] and is replaced by `data-root`[[2]].

We're currently on v20.10.5 so Docker's fallen back to using the default location of `/var/lib/docker` on the smaller drive.
This is likely the cause of the P4 incident where Docker used up all the available disk space and failed to build new images.

To release I'll rerun the Docker-related Ansible tasks which will apply the change and restart Docker. I have checked and I don't think we need to copy any files over from `/var/lib/docker` to `/data/docker` - Docker should be able to sort itself out.

https://trello.com/c/LkA70qqT/812-1-investigate-why-we-didnt-get-a-jenkins-low-disk-space-alert

[1]: https://docs.docker.com/engine/deprecated/#-g-and---graph-flags-on-dockerd
[2]: https://stackoverflow.com/questions/24309526/how-to-change-the-docker-image-installation-directory/50217666#50217666