### PR TITLE
Harden SSH config

### DIFF
--- a/playbooks/jenkins_playbook.yml
+++ b/playbooks/jenkins_playbook.yml
@@ -13,3 +13,5 @@
       ClientAliveInterval: 45
       LogLevel: VERBOSE
       PasswordAuthentication: no
+      PermitRootLogin: no
+      X11Forwarding: no


### PR DESCRIPTION
https://trello.com/c/WSLu52Lf

Our latest IT health check recommended hardening the SSH config for Jenkins.

* Disable root login. We never do this, and I can't think of any circumstances where we'd want to. We always instead log in as another user and use sudo.
* Disable X11 forwarding. I don't think this is something we need, so there's no harm in disabling it.

I am deliberately not doing two further bits of hardening that were suggested:

* Set ListenAddress - Jenkins only has one external IP address, so this would add significant complexity for no security benefit.
* Change SSH port - this is a public repo, so the security benefit of changing to a different port would be minimal. It would also add significant new complexity to processes for maintaining Jenkins.