### PR TITLE
Notify Slack if the code backup job fails

### DIFF
--- a/job_definitions/code_backups.yml
+++ b/job_definitions/code_backups.yml
@@ -57,6 +57,18 @@
           ignore-post-commit-hooks: True
     wrappers:
       - ansicolor
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=code-backups
+              JOB=Backup code repository {{ package }}
+              ICON=:card_index_dividers:
+              STAGE=production
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           rm -rf {{ package }}


### PR DESCRIPTION
Previously we didn't get a notification in Slack if the code backup jobs failed. This could cause problems if we needed to use them and found out at that point that they weren't working.

Uses a [publisher](https://docs.openstack.org/infra/jenkins-job-builder/publishers.html) to trigger an action after the build completes. See the [`export_supplier_data_to_s3`](https://github.com/alphagov/digitalmarketplace-jenkins/blob/main/job_definitions/export_supplier_data_to_s3.yml) job for an example of how we already use this syntax.

https://trello.com/c/07xZl8W7/973-1-we-dont-get-an-alert-when-our-code-backup-jobs-fail