### PR TITLE
Revert "Bump ansible from 3.3.0 to 4.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==4.0.0
+ansible==3.3.0


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-jenkins#425

The upgrade to Ansible 4 is causing problems on Jenkins. Let's revert this PR until I've been able to understand why