### PR TITLE
Throttle app pipelines to 4 concurrent jobs

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -27,9 +27,11 @@
       def run_functional_tests(stage) {
         waitUntil {
           try {
-            node {
-              build job: "functional-tests-${stage}"
-              return true
+            throttle(['AppPipelines']) {
+              node {
+                build job: "functional-tests-${stage}"
+                return true
+              }
             }
           } catch(error) {
             echo "Functional tests failed: ${error}"
@@ -64,10 +66,12 @@
         def vr_job = null
 
         waitUntil {
-          node {
-            vr_job = build job: job_name, parameters: [
-              string(name: "COMMAND", value: "test"),
-            ], propagate: false
+          throttle(['AppPipelines']) {
+            node {
+              vr_job = build job: job_name, parameters: [
+                string(name: "COMMAND", value: "test"),
+              ], propagate: false
+            }
           }
 
           def vr_job_result = vr_job.result
@@ -106,10 +110,12 @@
               if (test_job_last_build_number == vr_job_number) {
                 echo "Verified that the last visual regression job built was triggered by this pipeline. Approving."
                 try {
-                  node {
-                    build job: job_name, parameters: [
-                      string(name: "COMMAND", value: "approve"),
-                    ]
+                  throttle(['AppPipelines']) {
+                    node {
+                      build job: job_name, parameters: [
+                        string(name: "COMMAND", value: "approve"),
+                      ]
+                    }
                   }
 
                 } catch(inside_error) {
@@ -133,44 +139,50 @@
       }
 
       stage('Create release tag') {
-        node {
-          git url: "git@github.com:alphagov/digitalmarketplace-{{ application }}.git",
-              branch: 'main', credentialsId: 'github_com_and_enterprise', poll: true
-          releaseHash = sh(
-              script: "git rev-parse --short HEAD",
-              returnStdout: true
-          ).trim()
+        throttle(['AppPipelines']) {
+          node {
+            git url: "git@github.com:alphagov/digitalmarketplace-{{ application }}.git",
+                branch: 'main', credentialsId: 'github_com_and_enterprise', poll: true
+            releaseHash = sh(
+                script: "git rev-parse --short HEAD",
+                returnStdout: true
+            ).trim()
 
-          if (releaseHash == "") {
-              throw new Exception('Release hash can not be found')
+            if (releaseHash == "") {
+                throw new Exception('Release hash can not be found')
+            }
+
+            releaseName = "release-${releaseHash}"
+
+            tag_release(releaseName)
+
+            echo "Release git hash: ${releaseHash}"
+            currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
           }
-
-          releaseName = "release-${releaseHash}"
-
-          tag_release(releaseName)
-
-          echo "Release git hash: ${releaseHash}"
-          currentBuild.displayName = "#${BUILD_NUMBER} - ${releaseName}"
         }
       }
 
       stage('Build') {
-        node {
-          build job: "build-image", parameters: [
-            string(name: "REPOSITORY", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "build-image", parameters: [
+              string(name: "REPOSITORY", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
 
       {% if application in dm_db_applications %}
       stage('DB migration on preview') {
-        node {
-          build job: "database-migration-paas", parameters: [
-            string(name: "STAGE", value: "preview"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "database-migration-paas", parameters: [
+              string(name: "STAGE", value: "preview"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
 
@@ -182,17 +194,19 @@
       {% endif %}
 
       stage('Release to preview') {
-        node {
-          build job: "release-app-paas", parameters: [
-            string(name: "STAGE", value: "preview"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
-          build job: "tag-application-deployment", parameters: [
-            string(name: "STAGE", value: "preview"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "release-app-paas", parameters: [
+              string(name: "STAGE", value: "preview"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+            build job: "tag-application-deployment", parameters: [
+              string(name: "STAGE", value: "preview"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
 
@@ -213,12 +227,14 @@
         milestone()
         input(message: "Release to staging?")
         milestone()
-        node {
-          build job: "database-migration-paas", parameters: [
-            string(name: "STAGE", value: "staging"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "database-migration-paas", parameters: [
+              string(name: "STAGE", value: "staging"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
 
@@ -235,17 +251,19 @@
         input(message: "Release to staging?")
         milestone()
         {% endif %}
-        node {
-          build job: "release-app-paas", parameters: [
-            string(name: "STAGE", value: "staging"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
-          build job: "tag-application-deployment", parameters: [
-            string(name: "STAGE", value: "staging"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "release-app-paas", parameters: [
+              string(name: "STAGE", value: "staging"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+            build job: "tag-application-deployment", parameters: [
+              string(name: "STAGE", value: "staging"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
 
@@ -266,12 +284,14 @@
         milestone()
         input(message: "Release to production?")
         milestone()
-        node {
-          build job: "database-migration-paas", parameters: [
-            string(name: "STAGE", value: "production"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
+        throttle(['AppPipelines']) {
+          node {
+            build job: "database-migration-paas", parameters: [
+              string(name: "STAGE", value: "production"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+          }
         }
       }
       {% endif %}
@@ -282,18 +302,20 @@
         input(message: "Release to production?")
         milestone()
         {% endif %}
-        node {
-          build job: "release-app-paas", parameters: [
-            string(name: "STAGE", value: "production"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
-          build job: "tag-application-deployment", parameters: [
-            string(name: "STAGE", value: "production"),
-            string(name: "APPLICATION_NAME", value: "{{ application }}"),
-            string(name: "RELEASE_NAME", value: "${releaseName}"),
-          ]
-          build job: "apps-are-working-production", wait: false
+        throttle(['AppPipelines']) {
+          node {
+            build job: "release-app-paas", parameters: [
+              string(name: "STAGE", value: "production"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+            build job: "tag-application-deployment", parameters: [
+              string(name: "STAGE", value: "production"),
+              string(name: "APPLICATION_NAME", value: "{{ application }}"),
+              string(name: "RELEASE_NAME", value: "${releaseName}"),
+            ]
+            build job: "apps-are-working-production", wait: false
+          }
         }
       }
 {% endfor %}

--- a/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
@@ -17,6 +17,11 @@
       <categoryName>EndToEndTest-production</categoryName>
       <nodeLabeledPairs/>
     </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentTotal>4</maxConcurrentTotal>
+      <categoryName>AppPipelines</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
   </categories>
   <throttledPipelinesByCategory class="tree-map"/>
 </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl>


### PR DESCRIPTION
https://trello.com/c/FA715OCK/1566-prevent-jenkins-deadlocks

We just had Jenkins deadlock. This is because we had a large number of app pipeline jobs all in progress. However, they were all blocked on a deploy job, so could not make progress. However, all the deploy jobs were blocked on other jobs, mainly notifying Slack. However, the jobs in this third tier couldn't be scheduled because all the executors were full of blocked jobs in the first and second tier. We had to cancel a bunch of jobs to clear the deadlock.

Introduce [throttling](https://plugins.jenkins.io/throttle-concurrents/#throttling-of-pipeline-jobs) on the app pipelines. Now, no more than 4 can run at once. This means that in the worst case, only 12 executor slots will be occupied by jobs related to app pipelines. So other jobs will still be able to run. I think this should make it much harder to accidentally deadlock Jenkins, and allow us to merge with impunity.

We previously tried doing this in https://github.com/alphagov/digitalmarketplace-jenkins/pull/400. That didn't work because the throttling was done on too wide a scope, so picked up pipelines that weren't even trying to make progress. I think this approach should work, by only throttling just before we want to allocate an executor node.

Let's see if this works, and quickly revert if not.