### PR TITLE
Update to Ansible 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ ${VIRTUALENV_ROOT}/activate:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: requirements
-requirements: venv ## Install requirements
+requirements: venv ## Install requirements; TODO: remove uninstall once everyone's on Ansible 4
 	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
+	${VIRTUALENV_ROOT}/bin/pip show ansible | grep -q "Version: 4" || ${VIRTUALENV_ROOT}/bin/pip uninstall --yes ansible ansible-base ansible-core
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
 	${VIRTUALENV_ROOT}/bin/ansible-galaxy install -r playbooks/requirements.yml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==3.3.0
+ansible==4.1.0


### PR DESCRIPTION
We can't simply upgrade from ansible 3 to 4 with pip - it doesn't work.

So detect whether the venv has got ansible 4 and uninstall ansible if not. This will allow the upgrade to ansible 4 to happen automatically without errors.