### PR TITLE
Run functional tests using headless Firefox

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "aws-auth.nix|tests/jenkins-vars.yml",
     "lines": null
   },
-  "generated_at": "2020-10-08T12:52:30Z",
+  "generated_at": "2021-07-01T14:18:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -104,14 +104,14 @@
         "hashed_secret": "f373ec053d76b4cb1a707326da4841b8b748b52e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 92,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 117,
         "type": "Secret Keyword"
       }
     ],

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -124,5 +124,9 @@
 
           export DM_ENVIRONMENT={{ job.environment }}
 
+          export BROWSER=true
+
+          export HEADLESS=true
+
           make run-parallel && make build-report || ( make build-report; make rerun )
 {% endfor %}

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -22,6 +22,7 @@ dist_tools:
   - bzip2
   - curl
   - fonts-liberation
+  - firefox
   - git
   - gnupg2
   - libffi-dev


### PR DESCRIPTION
Our tests are currently rather unreliable. I have a hypothesis that this might be PhantomJS-related and that switching to Selenium might improve things.

Do an experiment to find out whether this is the case. Build on https://github.com/alphagov/digitalmarketplace-functional-tests/pull/901 to switch the functional test jobs over to use Selenium with headless firefox. Install firefox so that this works.

My plan is to deploy it and see what happens. Should be quick and easy to revert if it breaks things.

Also, detect-secrets picked up some old unrelated changes.