### PR TITLE
Stop changing the jenkins user's primary group

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_docker.yml
+++ b/playbooks/roles/jenkins/tasks/05_docker.yml
@@ -21,7 +21,10 @@
   group: name=docker
 
 - name: Add jenkins user to the docker group
-  user: name=jenkins group=docker append=yes
+  user:
+    name: jenkins
+    groups: [docker]
+    append: yes
   notify: restart docker
 
 - name: Create docker image graph/cache directory


### PR DESCRIPTION
We create the user in bootstrap, where we (correctly) set jenkins as the primary group. However, it looks as if we were incorrectly then changing the primary group to docker by using 'group' rather than 'groups' - see https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-group

Change to use the correct parameter name, and also switch to the new way of providing parameters.