### PR TITLE
Ansible changes to support Ubuntu 20 LTS

### DIFF
--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,6 +1,7 @@
 [jenkins]
 ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06bc719ccbe9a20db
 # ci3.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol00bfc5f17f9313c72
+ci-test.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0ddf715848437b857
 
 [jenkins:vars]
 ansible_python_interpreter=/usr/bin/python3

--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,5 +1,5 @@
 [jenkins]
-ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06bc719ccbe9a20db
+# ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06bc719ccbe9a20db
 # ci3.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol00bfc5f17f9313c72
 ci-test.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol07860259144c2490c
 

--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,7 +1,7 @@
 [jenkins]
 ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06bc719ccbe9a20db
 # ci3.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol00bfc5f17f9313c72
-ci-test.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0ddf715848437b857
+ci-test.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol07860259144c2490c
 
 [jenkins:vars]
 ansible_python_interpreter=/usr/bin/python3

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -24,10 +24,12 @@ dist_tools:
   - fonts-liberation
   - git
   - gnupg2
+  - jq
   - libffi-dev
   - libpq-dev
   - libreadline-dev
   - libsqlite3-dev
+  - libssl-dev
   - libyaml-dev
   - make
   - ntp

--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -19,6 +19,7 @@ jobs: '*'
 jobs_disabled: false
 
 dist_tools:
+  - acl
   - bzip2
   - curl
   - fonts-liberation

--- a/playbooks/roles/jenkins/tasks/05_docker.yml
+++ b/playbooks/roles/jenkins/tasks/05_docker.yml
@@ -7,7 +7,7 @@
 
 - name: Add Docker repository
   apt_repository:
-    repo: "deb https://download.docker.com/linux/ubuntu bionic stable"
+    repo: "deb https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
     update_cache: yes
 

--- a/playbooks/roles/jenkins/tasks/05_gdrive.yml
+++ b/playbooks/roles/jenkins/tasks/05_gdrive.yml
@@ -2,9 +2,9 @@
 
 - name: Install gdrive (google drive command line interface client)
   get_url:
-    url: "https://github.com/gdrive-org/gdrive/releases/download/2.1.0/gdrive-linux-x64"
+    url: "https://raw.githubusercontent.com/AnimMouse/gdrive-binaries/master/linux/gdrive-linux-x64"
     dest: /usr/local/bin/gdrive
-    checksum: sha1:6ef7c740e980358a9a5de36c1aac7ea375319aa3
+    checksum: sha1:4fd8391b300cac45963e53da44dcfe68da08d843
     mode: 0755
 
 - name: Add local .gdrive directory

--- a/playbooks/roles/jenkins/tasks/05_jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/05_jenkins.yml
@@ -41,11 +41,6 @@
   ignore_errors: yes
   when: not (first_time_install_test is failed)
 
-- name: Create Jenkins admin password hash
-  shell: echo -n "{{ jenkins_admin_password }}{ansible_jenkins}" | sha256sum - | awk '{ print $1; }'
-  when: not (first_time_install_test is failed)
-  register: jenkins_password_hash
-
 - name: Find Jenkins admin user directory
   when: not (first_time_install_test is failed)
   find:
@@ -59,7 +54,7 @@
   lineinfile:
     path: "{{ jenkins_user_admin.files[0].path }}/config.xml"
     regexp: '^(\s)*<passwordHash>(.*)'
-    line: '      <passwordHash>ansible_jenkins:{{ jenkins_password_hash.stdout }}</passwordHash>'
+    line: '      <passwordHash>{{ jenkins_admin_password_hash }}</passwordHash>'
     owner: "jenkins"
 
 - name: Forced restart to pick up any changes

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -14,7 +14,7 @@
 
 - name: Add Postgres repo to sources list
   tags: [apt]
-  apt_repository: repo='deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' state=present
+  apt_repository: repo='deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main' state=present
 
 - name: Install tools
   tags: [apt]
@@ -38,7 +38,7 @@
 - name: Install wkhtmltopdf with patched qt
   tags: [apt]
   apt:
-    deb: https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
+    deb: https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.{{ ansible_distribution_release }}_amd64.deb
     state: present
 
 - name: Update Python 3 pip

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -47,7 +47,7 @@
 
 - name: Install AWS cli
   pip:
-    name: awscli==1.16.109
+    name: awscli==1.19.110
     state: present
 
 - name: Create AWS cli config folder

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -31,9 +31,7 @@
     update_cache: yes
     state: present
     name:
-      - jq=1.5+dfsg-*
-      - nodejs=8.*
-      - libssl1.0-dev
+      - nodejs=10.*
 
 - name: Install wkhtmltopdf with patched qt
   tags: [apt]

--- a/playbooks/roles/jenkins/tasks/10_jobs.yml
+++ b/playbooks/roles/jenkins/tasks/10_jobs.yml
@@ -12,8 +12,14 @@
 - name: Create /var/lib/jenkins/jenkins_jobs/definitions
   file: path=/var/lib/jenkins/jenkins_jobs/definitions state=directory recurse=yes owner=jenkins
 
+- name: Create jenkins job config directory
+  file:
+    path: /etc/jenkins_jobs
+    state: directory
+    owner: jenkins
+
 - name: Deploy jenkins_jobs.ini
-  template: dest=/var/lib/jenkins/jenkins_jobs/jenkins_jobs.ini src=jenkins_jobs.ini.j2 owner=jenkins
+  template: dest=/etc/jenkins_jobs/jenkins_jobs.ini src=jenkins_jobs.ini.j2 owner=jenkins
 
 - name: Clone digitalmarketplace-credentials repository
   tags: [credentials-repo]


### PR DESCRIPTION
https://trello.com/c/cacoWXHC/63-5-upgrade-the-version-of-python-on-jenkins-to-at-least-38

Ansible changes to support Ubuntu 20 LTS. Alongside fixes for various out of date dependencies and other issues spotted along the way (please see commit messages for specific details).

See also sister PRs https://github.com/alphagov/digitalmarketplace-aws/pull/956 & https://github.com/alphagov/digitalmarketplace-credentials/pull/401
