### PR TITLE
remove phantomjs

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -115,19 +115,3 @@
 
 - name: Kill gpg-agent
   command: gpgconf --kill gpg-agent
-
-# TODO: Stop installing PhantomJS when it has been fully removed from our tests
-- name: Download PhantomJS
-  get_url:
-    url: "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
-    checksum: md5:1c947d57fce2f21ce0b43fe2ed7cd361
-    dest: /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2
-
-- name: Unarchive PhantomJS
-  unarchive:
-    src: /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2
-    dest: /usr/local/src
-    copy: no
-
-- name: Install PhantomJS binary
-  file: src=/usr/local/src/phantomjs-2.1.1-linux-x86_64/bin/phantomjs dest=/usr/local/bin/phantomjs state=link


### PR DESCRIPTION
since https://github.com/alphagov/digitalmarketplace-functional-tests/pull/912 we no longer depend on phantomjs for functional tests.