### PR TITLE
Change default scripts branch to main in signature job

### DIFF
--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -62,7 +62,7 @@
                 git url: 'git@github.com:alphagov/digitalmarketplace-scripts.git', branch: 'main', credentialsId: 'github_com_and_enterprise', poll: true
                 sh('''
                   git clean -fdx
-                  git reset --hard origin/master
+                  git reset --hard origin/main
 
                   pip install -U digitalmarketplace-developer-tools
                   invoke virtualenv


### PR DESCRIPTION
This must have been missed in #415. The `master` branch no longer exists so this job is now failing.