### PR TITLE
Install Chrome from Google's package repository

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -21,11 +21,11 @@ jobs_disabled: false
 dist_tools:
   - acl
   - bzip2
-  - chromium-chromedriver
   - curl
   - fonts-liberation
   - git
   - gnupg2
+  - google-chrome-stable=92.0.4515.131-1
   - jq
   - libffi-dev
   - libpq-dev

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -16,6 +16,25 @@
   tags: [apt]
   apt_repository: repo='deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main' state=present
 
+- name: Add key for Chrome repo
+  tags: [apt]
+  apt_key:
+    url: https://dl-ssl.google.com/linux/linux_signing_key.pub
+
+- name: Add Chrome repo to sources list
+  tags: [apt]
+  apt_repository:
+    repo: deb http://dl.google.com/linux/chrome/deb/ stable main
+    state: present
+
+- name: Install Chromedriver binary
+  tags: [apt]
+  unarchive:
+    src: "https://chromedriver.storage.googleapis.com/92.0.4515.43/chromedriver_linux64.zip"
+    dest: /usr/local/bin
+    mode: 0755
+    remote_src: yes
+
 - name: Install tools
   tags: [apt]
   apt:


### PR DESCRIPTION
We recently changed our functional tests to use Selenium, Chromedriver and Chrome to remove a very old dependency on PhantomJS. These all pass locally, however on Jenkins all the tests that require uploading a file fail.

The obvious difference between running the tests locally against Preview and running them on Jenkins is the version of Chrome / Chromedriver. On Jenkins we were using Chromium and Chromedriver from the Ubuntu package registry. This is unfortunately quite old - version 80 whereas the current stable version of Chrome is 92.

We can instead install Chrome from Google's package repository plus the relevant version of Chromedriver. This should hopefully fix the problems we're having.

While testing, we have already added the Google package repository and key to Jenkins and verified that the `google-chrome-stable` package is in that repository. To deploy the rest of the changes I will need to SSH into Jenkins and uninstall the current Chromium and Chromedriver with
```
snap remove chromium
apt purge chromium-browser chromium-chromedriver
```

Then I can run 
```
TAGS=apt make jenkins
```
to install the new versions

https://trello.com/c/pVDEUtX9/101-functional-tests-that-require-file-uploads-are-failing-on-jenkins