### PR TITLE
Send all Slack notifications to #dm-2ndline

### DIFF
--- a/job_definitions/build_image.yml
+++ b/job_definitions/build_image.yml
@@ -77,7 +77,7 @@
                       string(name: 'USERNAME', value: 'build-image'),
                       string(name: 'ICON', value: ':sad-docker:'),
                       string(name: 'JOB', value: "Build Docker image: ${REPOSITORY} - ${RELEASE_NAME}"),
-                      string(name: 'CHANNEL', value: "#dm-release"),
+                      string(name: 'CHANNEL', value: "#dm-2ndline"),
                       string(name: 'PROJECT', value: "${REPOSITORY}"),
                       text(name: 'RELEASE_NAME', value: "${RELEASE_NAME}"),
                       text(name: 'STATUS', value: 'FAILED'),

--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -56,7 +56,7 @@
           string(name: 'USERNAME', value: "clean-and-apply-db-dump"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Clean and apply database dump to {{ environment }}"),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "{{ environment }}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/create_index.yml
+++ b/job_definitions/create_index.yml
@@ -48,7 +48,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$SERIAL" = "true" ]; then

--- a/job_definitions/data_retention.yml
+++ b/job_definitions/data_retention.yml
@@ -24,7 +24,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/database_migration_paas.yml
+++ b/job_definitions/database_migration_paas.yml
@@ -26,7 +26,7 @@
                 string(name: 'USERNAME', value: "database-migration-paas"),
                 string(name: 'ICON', value: icon),
                 string(name: 'JOB', value: "Run database migrations for ${APPLICATION_NAME} on ${STAGE}"),
-                string(name: 'CHANNEL', value: "#dm-release"),
+                string(name: 'CHANNEL', value: "#dm-2ndline"),
                 string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
                 text(name: 'STAGE', value: "${STAGE}"),
                 text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),

--- a/job_definitions/docker_base_images.yml
+++ b/job_definitions/docker_base_images.yml
@@ -67,7 +67,7 @@
               string(name: 'USERNAME', value: 'build-and-push-base-images'),
               string(name: 'ICON', value: ':happy-docker:'),
               string(name: 'JOB', value: "Build and push docker base images"),
-              string(name: 'CHANNEL', value: "#dm-release"),
+              string(name: 'CHANNEL', value: "#dm-2ndline"),
               text(name: 'STATUS', value: "SUCCESS"),
               text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
             ]
@@ -81,7 +81,7 @@
               string(name: 'USERNAME', value: 'build-and-push-base-images'),
               string(name: 'ICON', value: ':sad-docker:'),
               string(name: 'JOB', value: "Build and push docker base images"),
-              string(name: 'CHANNEL', value: "#dm-release"),
+              string(name: 'CHANNEL', value: "#dm-2ndline"),
               text(name: 'STATUS', value: "FAILED"),
               text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
             ]

--- a/job_definitions/export_dos_opportunities.yml
+++ b/job_definitions/export_dos_opportunities.yml
@@ -19,7 +19,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
 

--- a/job_definitions/export_supplier_data_to_s3.yml
+++ b/job_definitions/export_supplier_data_to_s3.yml
@@ -24,7 +24,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL={{'#dm-2ndline' if environment == 'production' else '#dm-release'}}
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
 

--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -57,7 +57,7 @@
               STAGE={{ job.environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}functional_test_report|${BUILD_DISPLAY_NAME}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
           - project: notify-slack
             condition: SUCCESS
             predefined-parameters: |
@@ -67,7 +67,7 @@
               STAGE={{ job.environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - build-name-setter:
           template: "#${BUILD_NUMBER} - ${FT_BRANCH_NAME}"

--- a/job_definitions/general_docker_script_runner.yml
+++ b/job_definitions/general_docker_script_runner.yml
@@ -17,7 +17,7 @@
               ICON=:whale:
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
           - project: notify-slack
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
@@ -26,7 +26,7 @@
               ICON=:railfail:
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           docker run --rm digitalmarketplace/scripts $RUN_COMMAND

--- a/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
+++ b/job_definitions/generate_upload_and_notify_counterpart_signature_pages.yml
@@ -115,7 +115,7 @@
               string(name: 'ICON', value: ':alarm_clock:'),
               string(name: 'STAGE', value: "${ENVIRONMENT}"),
               string(name: 'STATUS', value: 'FAILED'),
-              string(name: 'CHANNEL', value: ENVIRONMENT == 'production' ? '#dm-2ndline' : '#dm-release'),
+              string(name: 'CHANNEL', value: '#dm-2ndline'),
               text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
             ]
           }

--- a/job_definitions/index_services.yml
+++ b/job_definitions/index_services.yml
@@ -28,7 +28,7 @@
               string(name: 'STAGE', value: "{{ environment }}"),
               string(name: 'STATUS', value: "FAILED"),
               string(name: 'URL', value: "<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>"),
-              string(name: 'CHANNEL', value: "{{'#dm-2ndline' if environment == 'production' else '#dm-release'}}")
+              string(name: 'CHANNEL', value: "#dm-2ndline")
             ]
           }
         }

--- a/job_definitions/maintenance_mode.yml
+++ b/job_definitions/maintenance_mode.yml
@@ -31,7 +31,7 @@
           string(name: 'USERNAME', value: "maintenance-mode"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Toggle maintenance mode on ${STAGE}"),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "${STAGE}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/mark_definite_framework_results.yml
+++ b/job_definitions/mark_definite_framework_results.yml
@@ -33,7 +33,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
           - project: notify-slack
             condition: SUCCESS
             predefined-parameters: |
@@ -43,7 +43,7 @@
               STAGE={{ environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     wrappers:
       - build-user-vars
     builders:

--- a/job_definitions/notify-suppliers-reminder-sign-agreement.yml
+++ b/job_definitions/notify-suppliers-reminder-sign-agreement.yml
@@ -67,7 +67,7 @@
                     string(name: 'USERNAME', value: 'remind-suppliers-to-sign-framework-agreement-(43)'),
                     string(name: 'ICON', value: ':e-mail:'),
                     string(name: 'JOB', value: "Remind suppliers to sign framework agreement (43)"),
-                    string(name: 'CHANNEL', value: "#dm-release"),
+                    string(name: 'CHANNEL', value: "#dm-2ndline"),
                     text(name: 'STATUS', value: "SUCCESS"),
                     text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
                   ]

--- a/job_definitions/notify_slack.yml
+++ b/job_definitions/notify_slack.yml
@@ -20,7 +20,7 @@
       - choice:
           name: CHANNEL
           choices:
-            - "#dm-release"
+            - "#dm-2ndline"
             - "#dm-2ndline"
       - string:
           name: PROJECT
@@ -46,7 +46,7 @@
 
           USERNAME = os.getenv('USERNAME', 'deploy')
           ICON = os.getenv('ICON', ':shipit:')
-          CHANNEL = os.getenv('CHANNEL', '#dm-release')
+          CHANNEL = os.getenv('CHANNEL', '#dm-2ndline')
           SLACK_URL = '{{ jenkins_slack_dm2ndline_url }}' if CHANNEL == '#dm-2ndline' else '{{ jenkins_slack_dmrelease_url }}'
 
           TEXT = os.getenv('TEXT', '')

--- a/job_definitions/notify_suppliers_intention_to_award.yml
+++ b/job_definitions/notify_suppliers_intention_to_award.yml
@@ -71,7 +71,7 @@
                     string(name: 'USERNAME', value: 'notify-suppliers-of-intention-to-award-(41)'),
                     string(name: 'ICON', value: ':e-mail:'),
                     string(name: 'JOB', value: "Notify suppliers of Intention To Award (41)"),
-                    string(name: 'CHANNEL', value: "#dm-release"),
+                    string(name: 'CHANNEL', value: "#dm-2ndline"),
                     text(name: 'STATUS', value: "SUCCESS"),
                     text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")
                   ]

--- a/job_definitions/notify_suppliers_of_framework_application_events.yml
+++ b/job_definitions/notify_suppliers_of_framework_application_events.yml
@@ -67,7 +67,7 @@
               STAGE={{ environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ -n "$RESUME_RUN_ID" ]; then

--- a/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
+++ b/job_definitions/notify_suppliers_whether_application_made_for_framework.yml
@@ -29,7 +29,7 @@
               STAGE={{ environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
           - project: notify-slack
             condition: UNSTABLE_OR_WORSE
             predefined-parameters: |
@@ -39,7 +39,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/notify_suppliers_with_incomplete_applications.yml
+++ b/job_definitions/notify_suppliers_with_incomplete_applications.yml
@@ -48,7 +48,7 @@
               STAGE={{ environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/publish_draft_services.yml
+++ b/job_definitions/publish_draft_services.yml
@@ -51,7 +51,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
           - project: notify-slack
             condition: SUCCESS
             predefined-parameters: |
@@ -61,7 +61,7 @@
               STAGE={{ environment }}
               STATUS=SUCCESS
               URL=<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/job_definitions/release_application_paas.yml
+++ b/job_definitions/release_application_paas.yml
@@ -29,7 +29,7 @@
             string(name: 'USERNAME', value: "release-application-to-paas"),
             string(name: 'ICON', value: icon),
             string(name: 'JOB', value: "Release ${APPLICATION_NAME} to ${STAGE}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
+            string(name: 'CHANNEL', value: "#dm-2ndline"),
             string(name: 'PROJECT', value: "${APPLICATION_NAME}"),
             text(name: 'STAGE', value: "${STAGE}"),
             text(name: 'RELEASE_NAME', value: "<https://github.com/alphagov/digitalmarketplace-${APPLICATION_NAME}/tree/${RELEASE_NAME}|${RELEASE_NAME}>"),

--- a/job_definitions/rerelease_all.yml
+++ b/job_definitions/rerelease_all.yml
@@ -37,7 +37,7 @@
           string(name: 'USERNAME', value: "rerelease-all-apps"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: job),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "${STAGE}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/rotate_api_tokens.yml
+++ b/job_definitions/rotate_api_tokens.yml
@@ -74,7 +74,7 @@
           string(name: 'USERNAME', value: "rotate-api-tokens"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Rotate API tokens on ${STAGE}"),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "${STAGE}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/rotate_callback_token.yml
+++ b/job_definitions/rotate_callback_token.yml
@@ -57,7 +57,7 @@
           string(name: 'USERNAME', value: "rotate-api-tokens"),
           string(name: 'ICON', value: icon),
           string(name: 'JOB', value: "Rotate Notify callback token for {{ environment }}"),
-          string(name: 'CHANNEL', value: "#dm-release"),
+          string(name: 'CHANNEL', value: "#dm-2ndline"),
           text(name: 'STAGE', value: "{{ environment }}"),
           text(name: 'STATUS', value: status),
           text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/scan_g_cloud_services_for_bad_words.yml
+++ b/job_definitions/scan_g_cloud_services_for_bad_words.yml
@@ -26,7 +26,7 @@
             string(name: 'USERNAME', value: "scan-g-cloud-services-for-bad-words"),
             string(name: 'ICON', value: ":zipper_mouth_face:"),
             string(name: 'JOB', value: "Scan G-Cloud services for bad words - {{ environment }}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
+            string(name: 'CHANNEL', value: "#dm-2ndline"),
             text(name: 'STAGE', value: "{{ environment }}"),
             text(name: 'STATUS', value: status),
             text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -56,7 +56,7 @@
       - ansicolor
     dsl: |
 
-      def notify_slack(icon, status, channel = "#dm-release") {
+      def notify_slack(icon, status, channel = "#dm-2ndline") {
         build job: "notify-slack",
               parameters: [
                 string(name: 'USERNAME', value: '{{ test_type.slack_username }}'),

--- a/job_definitions/stats_snapshots.yml
+++ b/job_definitions/stats_snapshots.yml
@@ -75,7 +75,7 @@
             string(name: 'USERNAME', value: "upload-application-statistics-{{ environment }}"),
             string(name: 'ICON', value: ':sad-docker:'),
             string(name: 'JOB', value: "Upload application stats - {{ environment }}"),
-            string(name: 'CHANNEL', value: "#dm-release"),
+            string(name: 'CHANNEL', value: "#dm-2ndline"),
             text(name: 'STAGE', value: "{{ environment }}"),
             text(name: 'STATUS', value: 'FAILED'),
             text(name: 'URL', value: "<${BUILD_URL}consoleFull|${BUILD_DISPLAY_NAME}>")

--- a/job_definitions/update_index.yml
+++ b/job_definitions/update_index.yml
@@ -48,7 +48,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - shell: |
           if [ "$SERIAL" = "true" ]; then

--- a/job_definitions/visual_regression.yml
+++ b/job_definitions/visual_regression.yml
@@ -46,7 +46,7 @@
               STAGE={{ environment }}
               STATUS=FAILED
               URL=<${BUILD_URL}Visual_Regression_Test_Report|${BUILD_DISPLAY_NAME}>
-              CHANNEL=#dm-release
+              CHANNEL=#dm-2ndline
     builders:
       - conditional-step:
           condition-kind: strings-match
@@ -137,7 +137,7 @@
                   STAGE={{ environment }}
                   STATUS=SUCCESS
                   URL=<${BUILD_URL}Visual_Regression_Test_Report|${BUILD_DISPLAY_NAME}>
-                  CHANNEL=#dm-release
+                  CHANNEL=#dm-2ndline
 
       - conditional-step:
           condition-kind: and
@@ -159,5 +159,5 @@
                   STAGE={{ environment }}
                   STATUS=APPROVED
                   URL=<${BUILD_URL}Visual_Regression_Test_Report|${BUILD_DISPLAY_NAME}>
-                  CHANNEL=#dm-release
+                  CHANNEL=#dm-2ndline
 {% endfor %}


### PR DESCRIPTION
This is a temporary measure. Our CCS techops friends only have access to #dm-2ndline. So send all Slack notifications there so that they can see them. This will make that channel a lot more spammy, but I think that's an acceptable price to pay.

We should be able to revert this change once we've switched over to a CCS Slack (or equivalent) where we can use more than one channel.