### PR TITLE
Drop support for python < v3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ If you encounter Python 3.x/OpenSSL errors when running the Ansible playbooks, t
 
 ```bash
 $ pip install certifi
-$ export SSL_CERT_FILE=venv/lib/python3.6/site-packages/certifi/cacert.pem
+$ export SSL_CERT_FILE=venv/lib/python3.8/site-packages/certifi/cacert.pem
 ```
 
 If you still get a certificate error, try:
 
 ```bash
-$ open /Applications/Python\ 3.6/Install\ Certificates.command
+$ open /Applications/Python\ 3.8/Install\ Certificates.command
 ```
 
 ## SSH access to Jenkins


### PR DESCRIPTION
https://trello.com/c/XL6YJ30H/201-upgrade-everything-to-python-38-9

This is only a development requirement, but we still drop support for the older versions of Python.
This shouldn't affect anything as Jenkins is already using 3.8 and this is a development change which wont affect the Jenkins instance itself. 